### PR TITLE
Add client queue

### DIFF
--- a/Audio-Transcription-Chrome/background.js
+++ b/Audio-Transcription-Chrome/background.js
@@ -190,17 +190,19 @@ async function stopCapture() {
  * Listens for messages from the runtime and performs corresponding actions.
  * @param {Object} message - The message received from the runtime.
  */
-chrome.runtime.onMessage.addListener((message) => {
+chrome.runtime.onMessage.addListener(async (message) => {
   if (message.action === "startCapture") {
     startCapture(message);
   } else if (message.action === "stopCapture") {
     stopCapture();
   } else if (message.action === "updateSelectedLanguage") {
-    console.log("Selected language");
-    console.log(message.detectedLanguage);
     const detectedLanguage = message.detectedLanguage;
     chrome.runtime.sendMessage({ action: "updateSelectedLanguage", detectedLanguage });
     chrome.storage.local.set({ selectedLanguage: detectedLanguage });
+  } else if (message.action === "toggleCaptureButtons") {
+    chrome.runtime.sendMessage({ action: "toggleCaptureButtons", data: false });
+    chrome.storage.local.set({ capturingState: { isCapturing: false } })
+    stopCapture();
   }
 });
 

--- a/Audio-Transcription-Chrome/content.js
+++ b/Audio-Transcription-Chrome/content.js
@@ -6,6 +6,52 @@ var elem_text = null;
 var segments = [];
 var text_segments = [];
 
+function initPopupElement() {
+  if (document.getElementById('popupElement')) {
+    return;
+  }
+
+  const popupContainer = document.createElement('div');
+  popupContainer.id = 'popupElement';
+  popupContainer.style.cssText = 'position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); background: white; color: black; padding: 16px; border-radius: 10px; box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.5); display: none; text-align: center;';
+
+  const popupText = document.createElement('span');
+  popupText.textContent = 'Default Text';
+  popupText.className = 'popupText';
+  popupText.style.fontSize = '24px';
+  popupContainer.appendChild(popupText);
+
+  const buttonContainer = document.createElement('div');
+  buttonContainer.style.marginTop = '8px';
+  const closePopupButton = document.createElement('button');
+  closePopupButton.textContent = 'Close';
+  closePopupButton.style.backgroundColor = '#65428A';
+  closePopupButton.style.color = 'white';
+  closePopupButton.style.border = 'none';
+  closePopupButton.style.padding = '8px 16px'; // Add padding for better click area
+  closePopupButton.style.cursor = 'pointer';
+  closePopupButton.addEventListener('click', async () => {
+    popupContainer.style.display = 'none';
+    await browser.runtime.sendMessage({ action: 'toggleCaptureButtons', data: false });
+  });
+  buttonContainer.appendChild(closePopupButton);
+  popupContainer.appendChild(buttonContainer);
+
+  document.body.appendChild(popupContainer);
+}
+
+
+function showPopup(customText) {
+  const popup = document.getElementById('popupElement');
+  const popupText = popup.querySelector('.popupText');
+
+  if (popup && popupText) {
+      popupText.textContent = customText || 'Default Text'; // Set default text if custom text is not provided
+      popup.style.display = 'block';
+  }
+}
+
+
 function init_element() {
     if (document.getElementById('transcription')) {
         return;
@@ -128,11 +174,18 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         remove_element();
         sendResponse({data: "STOPPED"});
         return;
+    } else if (type === "showWaitPopup"){
+        initPopupElement();
+
+        showPopup(`Estimated wait time ~ ${Math.round(data)} minutes`);
+        sendResponse({data: "popup"});
+        return;
     }
 
     init_element();
 
     message = JSON.parse(data);
+    message = message["segments"];
 
     var text = '';
     for (var i = 0; i < message.length; i++) {

--- a/Audio-Transcription-Chrome/options.html
+++ b/Audio-Transcription-Chrome/options.html
@@ -10,7 +10,6 @@
 </head>
 
 <body>
-    <script src="ort.min.js"></script>
     <script src="options.js"></script>
 </body>
 

--- a/Audio-Transcription-Chrome/options.js
+++ b/Audio-Transcription-Chrome/options.js
@@ -165,14 +165,7 @@ async function startRecord(option) {
 
       audioDataCache.push(inputData);
 
-      // feed inputs and run
-      const base64AudioData = btoa(String.fromCharCode.apply(null, new Uint8Array(audioData16kHz.buffer)));
-
-      socket.send(
-        JSON.stringify({
-          "audio": base64AudioData
-        })
-      );
+      socket.send(audioData16kHz);
     };
 
     // Prevent page mute

--- a/Audio-Transcription-Chrome/popup.js
+++ b/Audio-Transcription-Chrome/popup.js
@@ -119,6 +119,8 @@ document.addEventListener("DOMContentLoaded", function () {
     startButton.disabled = isCapturing;
     stopButton.disabled = !isCapturing;
     useServerCheckbox.disabled = isCapturing; 
+    useMultilingualCheckbox.disabled = isCapturing;
+    
     startButton.classList.toggle("disabled", isCapturing);
     stopButton.classList.toggle("disabled", !isCapturing);
   }
@@ -163,6 +165,13 @@ document.addEventListener("DOMContentLoaded", function () {
         languageDropdown.value = detectedLanguage;
         chrome.storage.local.set({ selectedLanguage: detectedLanguage });
       }
+    }
+  });
+
+  chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
+    if (request.action === "toggleCaptureButtons") {
+      toggleCaptureButtons(false);
+      chrome.storage.local.set({ capturingState: { isCapturing: false } })
     }
   });
   

--- a/Audio-Transcription-Firefox/background.js
+++ b/Audio-Transcription-Firefox/background.js
@@ -1,7 +1,7 @@
-browser.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+browser.runtime.onMessage.addListener(async function(request, sender, sendResponse) {
   const { action, data } = request;
   if (action === "transcript") {
-    browser.tabs.query({ active: true, currentWindow: true })
+    await browser.tabs.query({ active: true, currentWindow: true })
       .then((tabs) => {
         const tabId = tabs[0].id;
         browser.tabs.sendMessage(tabId, { action: "show_transcript", data });
@@ -12,9 +12,53 @@ browser.runtime.onMessage.addListener(function(request, sender, sendResponse) {
   }
   if (action === "updateSelectedLanguage") {
     const detectedLanguage = data;
-    if (detectedLanguage) {
-      browser.runtime.sendMessage({ action: "updateSelectedLanguage", detectedLanguage });
-      browser.storage.local.set({ selectedLanguage: detectedLanguage });
+    try {
+      await browser.storage.local.set({ selectedLanguage: detectedLanguage });
+      browser.tabs.query({ active: true, currentWindow: true }).then((tabs) => {
+        const tabId = tabs[0].id;
+        browser.tabs.sendMessage(tabId, { action: "updateSelectedLanguage", detectedLanguage });
+      });
+    } catch (error) {
+      console.error("Error updateSelectedLanguage:", error);
+    }
+  }
+  if (action === "toggleCaptureButtons") {    
+    try {
+      await browser.storage.local.set({ capturingState: { isCapturing: false } });
+      browser.tabs.query({ active: true, currentWindow: true }).then((tabs) => {
+        const tabId = tabs[0].id;
+        browser.tabs.sendMessage(tabId, { action: "toggleCaptureButtons", data: false });
+      });
+    } catch (error) {
+      console.error("Error updating capturing state:", error);
+    }
+
+    try{
+      await browser.tabs.query({ active: true, currentWindow: true })
+        .then((tabs) => {
+          const tabId = tabs[0].id;
+          browser.tabs.sendMessage(tabId, { action: "stopCapture", data });
+        })
+        .catch((error) => {
+          console.error("Error retrieving active tab:", error);
+        }); 
+    } catch (error) {
+      console.error(error);
+    }
+  }
+  
+  if (action === "showPopup") {
+    try{
+      await browser.tabs.query({ active: true, currentWindow: true })
+        .then((tabs) => {
+          const tabId = tabs[0].id;
+          browser.tabs.sendMessage(tabId, { action: "showWaitPopup", data });
+        })
+        .catch((error) => {
+          console.error(error);
+        });
+    } catch (error) {
+      console.error(error);
     }
   }
 });

--- a/Audio-Transcription-Firefox/content.js
+++ b/Audio-Transcription-Firefox/content.js
@@ -5,6 +5,20 @@ let audioContext = null;
 let scriptProcessor = null;
 let language = null;
 
+let isPaused = false;
+
+const mediaElements = document.querySelectorAll('video, audio');
+mediaElements.forEach((mediaElement) => {
+  mediaElement.addEventListener('play', handlePlaybackStateChange);
+  mediaElement.addEventListener('pause', handlePlaybackStateChange);
+});
+
+
+function handlePlaybackStateChange(event) {
+  isPaused = event.target.paused;
+}
+
+
 /**
  * Resamples the audio data to a target sample rate of 16kHz.
  * @param {Array|ArrayBuffer|TypedArray} audioData - The input audio data.
@@ -90,7 +104,7 @@ function startRecording(data) {
       recorder = audioContext.createScriptProcessor(4096, 1, 1);
 
       recorder.onaudioprocess = async (event) => {
-        if (!audioContext || !isCapturing || !isServerReady) return;
+        if (!audioContext || !isCapturing || !isServerReady || isPaused) return;
 
         const inputData = event.inputBuffer.getChannelData(0);
         const audioData16kHz = resampleTo16kHZ(inputData, audioContext.sampleRate);

--- a/Audio-Transcription-Firefox/content.js
+++ b/Audio-Transcription-Firefox/content.js
@@ -132,14 +132,7 @@ function startRecording(data) {
 
         audioDataCache.push(inputData);
         
-        // feed inputs and run
-        const base64AudioData = btoa(String.fromCharCode.apply(null, new Uint8Array(audioData16kHz.buffer)));
-        
-        socket.send(
-          JSON.stringify({
-            "audio": base64AudioData
-          })
-        );
+        socket.send(audioData16kHz);
       };
 
       // Prevent page mute

--- a/Audio-Transcription-Firefox/popup.html
+++ b/Audio-Transcription-Firefox/popup.html
@@ -15,6 +15,8 @@
     <input type="checkbox" id="useServerCheckbox">
     <label for="useServerCheckbox">Use Collabora Whisper-Live Server</label>
   </div>
+  <textarea id="waitTextBox" style="display: none;"></textarea>
+
   <div class="checkbox-container">
     <input type="checkbox" id="useMultilingualCheckbox">
     <label for="useMultilingualCheckbox">Use Multilingual Model</label>

--- a/Audio-Transcription-Firefox/popup.js
+++ b/Audio-Transcription-Firefox/popup.js
@@ -113,7 +113,9 @@ document.addEventListener("DOMContentLoaded", function() {
   function toggleCaptureButtons(isCapturing) {
     startButton.disabled = isCapturing;
     stopButton.disabled = !isCapturing;
-    useServerCheckbox.disabled = isCapturing; // Disable checkbox if capturing
+    useServerCheckbox.disabled = isCapturing;
+    useMultilingualCheckbox.disabled = isCapturing;
+
     startButton.classList.toggle("disabled", isCapturing);
     stopButton.classList.toggle("disabled", !isCapturing);
   }
@@ -152,13 +154,23 @@ document.addEventListener("DOMContentLoaded", function() {
 
   browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.action === "updateSelectedLanguage") {
-      const detectedLanguage = request.detectedLanguage;
+      const detectedLanguage = request.data;
   
       if (detectedLanguage) {
         languageDropdown.value = detectedLanguage;
         selectedLanguage = detectedLanguage;
         browser.storage.local.set({ selectedLanguage });
       }
+    }
+  });
+
+  browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    if (request.action === "toggleCaptureButtons") {
+      toggleCaptureButtons(false);
+      browser.storage.local.set({ capturingState: { isCapturing: false } })
+        .catch(function(error) {
+          console.error("Error storing capturing state:", error);
+        });
     }
   });
 });

--- a/run_server.py
+++ b/run_server.py
@@ -1,6 +1,7 @@
 
+import asyncio
 from whisper_live.server import TranscriptionServer
 
 if __name__ == "__main__":
     server = TranscriptionServer()
-    server.run("0.0.0.0", 9090)
+    server.run("0.0.0.0")

--- a/run_server.py
+++ b/run_server.py
@@ -1,5 +1,3 @@
-
-import asyncio
 from whisper_live.server import TranscriptionServer
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ README = (HERE / "README.md").read_text()
 
 # This call to setup() does all the work
 setup(name="whisper-live",
-      version="0.0.5",
+      version="0.0.6",
       description="A nearly-live implementation of OpenAI's Whisper.",
       long_description=README,
       long_description_content_type="text/markdown",

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -38,7 +38,7 @@ class TranscriptionServer:
         self.clients = {}
         self.websockets = {}
         self.clients_start_time = {}
-        self.max_clients = 1
+        self.max_clients = 4
         self.max_connection_time = 600 # in seconds
     
     def get_wait_time(self):

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -89,10 +89,7 @@ class TranscriptionServer:
         while True:
             try:
                 frame_data = websocket.recv()
-                data = json.loads(frame_data)
-                base64_audio = data["audio"]
-                binary_audio = base64.b64decode(base64_audio)
-                frame_np = np.frombuffer(binary_audio, dtype=np.float32)
+                frame_np = np.frombuffer(frame_data, dtype=np.float32)
 
                 try:
                     speech_prob = self.vad_model(torch.from_numpy(frame_np.copy()), self.RATE).item()
@@ -117,6 +114,7 @@ class TranscriptionServer:
 
 
             except Exception as e:
+                logging.error(e)
                 self.clients[websocket].cleanup()
                 self.clients.pop(websocket)
                 self.clients_start_time.pop(websocket)


### PR DESCRIPTION
- resolve mozilla client; not (empty)sending audio frames when content is paused.
- add client queue to support 4 clients at a time 10 minutes each.
- send wait time to clients waiting in the queue

- show popup in chrome/mozilla client with estimated wait time
- update python client to handle server messages