### PR TITLE
fix: keyError: 'model' in server, when using browser extension

### DIFF
--- a/Audio-Transcription-Chrome/options.js
+++ b/Audio-Transcription-Chrome/options.js
@@ -103,7 +103,7 @@ async function startRecord(option) {
           multilingual: option.multilingual,
           language: option.language,
           task: option.task,
-          model_size: option.modelSize
+          model: option.modelSize
         })
       );
     };

--- a/Audio-Transcription-Firefox/content.js
+++ b/Audio-Transcription-Firefox/content.js
@@ -78,7 +78,7 @@ function startRecording(data) {
             multilingual: data.useMultilingual,
             language: data.language,
             task: data.task,
-            model_size: data.modelSize
+            model: data.modelSize
         })
       );
     };


### PR DESCRIPTION
In latest version, brower extension is not working anymore. 
Here is the server side errors:
```
Traceback (most recent call last):
  File "/home/gchust/miniconda3/envs/whisperlive/lib/python3.11/site-packages/websockets/sync/server.py", line 499, in conn_handler
    handler(connection)
  File "/mnt/c/work/WhisperLive/whisper_live/server.py", line 168, in recv_audio
    model=options["model"],
          ~~~~~~~^^^^^^^^^
KeyError: 'model'
```

This is the payload send from the web browser extension
```
{'uid': '620a44b8-38d3-4967-8f36-df7272aa8eb4', 'multilingual': False, 'language': 'zh', 'task': 'transcribe', 'model_size': 'small'}
```

Looks like server expecting `model` from client. 

After the fix, I am able to use the extension now:

![image](https://github.com/collabora/WhisperLive/assets/5254737/8ef1a34a-aa17-47e8-a70f-c565c3b04e4e)

