### PR TITLE
Add scipy to server.txt

### DIFF
--- a/requirements/server.txt
+++ b/requirements/server.txt
@@ -7,3 +7,4 @@ openai-whisper
 kaldialign
 soundfile
 ffmpeg-python
+scipy


### PR DESCRIPTION
The server script uses scipy but is not installed with the current server requirements file.