### PR TITLE
implementing ssl for server and client;

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,25 @@ client = TranscriptionClient(
   9090,
   lang="en",
   translate=False,
-  model="small"
+  model="small",
+  secure_websocket=False,
+  sslopt={},
+)
+
+client("tests/jfk.wav")
+```
+
+- To transcribe an audio file with ssl:
+```python
+from whisper_live.client import TranscriptionClient
+client = TranscriptionClient(
+  "localhost",
+  9090,
+  lang="en",
+  translate=False,
+  model="small",
+  secure_websocket=True,
+  sslopt={"ca_certs": "cert.pem"},
 )
 
 client("tests/jfk.wav")
@@ -73,7 +91,9 @@ client = TranscriptionClient(
   9090,
   lang="hi",
   translate=True,
-  model="small"
+  model="small",
+  secure_websocket=False,
+  sslopt={},
 )
 client()
 ```

--- a/run_server.py
+++ b/run_server.py
@@ -1,4 +1,5 @@
 import argparse
+import ssl
 from whisper_live.server import TranscriptionServer
 
 if __name__ == "__main__":
@@ -21,12 +22,19 @@ if __name__ == "__main__":
     parser.add_argument('--trt_multilingual', '-m',
                         action="store_true",
                         help='Boolean only for TensorRT model. True if multilingual.')
+    parser.add_argument('--ssl_cert_path', '-ssl',
+                        type=str,
+                        default=None,
+                        help='Path to cert.pem and key.pem if ssl should be used.')
     args = parser.parse_args()
 
     if args.backend == "tensorrt":
         if args.trt_model_path is None:
             raise ValueError("Please Provide a valid tensorrt model path")
-
+    ssl_context = None
+    if args.ssl_cert_path is not None:
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ssl_context.load_cert_chain(certfile=f"{args.ssl_cert_path}/cert.pem", keyfile=f"{args.ssl_cert_path}/key.pem")
     server = TranscriptionServer()
     server.run(
         "0.0.0.0",
@@ -34,5 +42,6 @@ if __name__ == "__main__":
         backend=args.backend,
         faster_whisper_custom_model_path=args.faster_whisper_custom_model_path,
         whisper_tensorrt_path=args.trt_model_path,
-        trt_multilingual=args.trt_multilingual
+        trt_multilingual=args.trt_multilingual,
+        ssl_context=ssl_context
     )

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -218,7 +218,8 @@ class TranscriptionServer:
             backend="tensorrt", 
             faster_whisper_custom_model_path=None,
             whisper_tensorrt_path=None, 
-            trt_multilingual=False
+            trt_multilingual=False,
+            ssl_context=None
         ):
         """
         Run the transcription server.
@@ -236,7 +237,8 @@ class TranscriptionServer:
                 trt_multilingual=trt_multilingual
             ),
             host,
-            port
+            port,
+            ssl_context=ssl_context
         ) as server:
             server.serve_forever()
 


### PR DESCRIPTION
I'm using a cloud server to transcribe parts of the audio and thus encryption of the connection is vital for me. I simply implemented options for server and client to get additional ssl context. If left as in the default it will work as before. It should work with both self-signed certificates and regular CAs. I tested it locally.