### PR TITLE
Handle failure on systems without microphones

### DIFF
--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -66,13 +66,17 @@ class Client:
         self.timestamp_offset = 0.0
         self.audio_bytes = None
         self.p = pyaudio.PyAudio()
-        self.stream = self.p.open(
-            format=self.format,
-            channels=self.channels,
-            rate=self.rate,
-            input=True,
-            frames_per_buffer=self.chunk,
-        )
+        try:
+            self.stream = self.p.open(
+                format=self.format,
+                channels=self.channels,
+                rate=self.rate,
+                input=True,
+                frames_per_buffer=self.chunk,
+            )
+        except OSError as error:
+            print(f"[WARN]: Unable to access microphone. {error}")
+            self.stream = None
 
         if host is not None and port is not None:
             socket_url = f"ws://{host}:{port}"


### PR DESCRIPTION
On systems without a mic, catch the OSError and print a WARN log instead of just crashing.
In my case, I was just trying to do `client(hls_url=my_url)` which does not need a mic.

Example error on systems without mics.
```
---------------------------------------------------------------------------
OSError                                   Traceback (most recent call last)
<ipython-input-5-1bb0e2c6471f> in <cell line: 26>()
     48     sleep(15)
     49     logging.info("Starting client")
---> 50     client = TranscriptionClient(
     51         host="localhost",
     52         port=port,

3 frames
/usr/local/lib/python3.10/dist-packages/whisper_live/client.py in __init__(self, host, port, lang, translate, model, use_vad)
    508     """
    509     def __init__(self, host, port, lang=None, translate=False, model="small", use_vad=True):
--> 510         self.client = Client(host, port, lang, translate, model, srt_file_path="output.srt", use_vad=use_vad)
    511 
    512     def __call__(self, audio=None, hls_url=None):

/usr/local/lib/python3.10/dist-packages/whisper_live/client.py in __init__(self, host, port, lang, translate, model, srt_file_path, use_vad)
     67         self.audio_bytes = None
     68         self.p = pyaudio.PyAudio()
---> 69         self.stream = self.p.open(
     70             format=self.format,
     71             channels=self.channels,

/usr/local/lib/python3.10/dist-packages/pyaudio/__init__.py in open(self, *args, **kwargs)
    637         :returns: A new :py:class:`PyAudio.Stream`
    638         """
--> 639         stream = PyAudio.Stream(self, *args, **kwargs)
    640         self._streams.add(stream)
    641         return stream

/usr/local/lib/python3.10/dist-packages/pyaudio/__init__.py in __init__(self, PA_manager, rate, channels, format, input, output, input_device_index, output_device_index, frames_per_buffer, start, input_host_api_specific_stream_info, output_host_api_specific_stream_info, stream_callback)
    439 
    440             # calling pa.open returns a stream object
--> 441             self._stream = pa.open(**arguments)
    442 
    443             self._input_latency = self._stream.inputLatency

OSError: [Errno -9996] Invalid input device (no default output device)
```