### PR TITLE
Add options for handling multilingual input

### DIFF
--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -812,7 +812,7 @@ class ServeClientFasterWhisper(ServeClientBase):
         if info is not None:
             if (self.language is None) or (self.language != info.language):
                 self.set_language(info)
-        
+
         return result
 
     def get_previous_output(self):

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -165,6 +165,8 @@ class TranscriptionServer:
                 task=options["task"],
                 client_uid=options["uid"],
                 model=options["model"],
+                multilingual_input=options.get("multilingual_input"),
+                lang_filter=options.get("lang_filter"),
                 initial_prompt=options.get("initial_prompt"),
                 vad_parameters=options.get("vad_parameters"),
                 use_vad=self.use_vad,
@@ -681,7 +683,7 @@ class ServeClientTensorRT(ServeClientBase):
 
 
 class ServeClientFasterWhisper(ServeClientBase):
-    def __init__(self, websocket, task="transcribe", device=None, language=None, client_uid=None, model="small.en",
+    def __init__(self, websocket, task="transcribe", device=None, language=None, lang_filter=None, client_uid=None, model="small.en", multilingual_input=False,
                  initial_prompt=None, vad_parameters=None, use_vad=True):
         """
         Initialize a ServeClient instance.
@@ -694,6 +696,8 @@ class ServeClientFasterWhisper(ServeClientBase):
             task (str, optional): The task type, e.g., "transcribe." Defaults to "transcribe".
             device (str, optional): The device type for Whisper, "cuda" or "cpu". Defaults to None.
             language (str, optional): The language for transcription. Defaults to None.
+            lang_filter (List[str], optional): List of candidate languages to listen for.  Defaults to None, meaning listen for all known languages.
+            multilingual_input (bool, optional): True means the input stream may contain more than one language.  Defaults to False.
             client_uid (str, optional): A unique identifier for the client. Defaults to None.
             model (str, optional): The whisper model size. Defaults to 'small.en'
             initial_prompt (str, optional): Prompt for whisper inference. Defaults to None.
@@ -708,6 +712,8 @@ class ServeClientFasterWhisper(ServeClientBase):
         else:
             self.model_size_or_path = model
         self.language = "en" if self.model_size_or_path.endswith("en") else language
+        self.lang_filter = lang_filter
+        self.multilingual_input = multilingual_input
         self.task = task
         self.initial_prompt = initial_prompt
         self.vad_parameters = vad_parameters or {"threshold": 0.5}
@@ -797,13 +803,16 @@ class ServeClientFasterWhisper(ServeClientBase):
         result, info = self.transcriber.transcribe(
             input_sample,
             initial_prompt=self.initial_prompt,
-            language=self.language,
+            language=self.language if not self.multilingual_input else None,
+            lang_filter=self.lang_filter,
             task=self.task,
             vad_filter=self.use_vad,
             vad_parameters=self.vad_parameters if self.use_vad else None)
 
-        if self.language is None and info is not None:
-            self.set_language(info)
+        if info is not None:
+            if (self.language is None) or (self.language != info.language):
+                self.set_language(info)
+        
         return result
 
     def get_previous_output(self):

--- a/whisper_live/transcriber.py
+++ b/whisper_live/transcriber.py
@@ -187,6 +187,7 @@ class WhisperModel:
         self,
         audio: Union[str, BinaryIO, np.ndarray],
         language: Optional[str] = None,
+        lang_filter : List[str] = None,
         task: str = "transcribe",
         beam_size: int = 5,
         best_of: int = 5,
@@ -352,8 +353,12 @@ class WhisperModel:
                 results = self.model.detect_language(encoder_output)[0]
                 # Parse language names to strip out markers
                 all_language_probs = [(token[2:-2], prob) for (token, prob) in results]
+                filtered_language_probs = all_language_probs
+                if lang_filter:
+                    filtered_language_probs = [p for p in all_language_probs
+                                               if p[0] in lang_filter]
                 # Get top language token and probability
-                language, language_probability = all_language_probs[0]
+                language, language_probability = filtered_language_probs[0]
 
                 self.logger.info(
                     "Detected language '%s' with probability %.2f",

--- a/whisper_live/transcriber.py
+++ b/whisper_live/transcriber.py
@@ -355,8 +355,26 @@ class WhisperModel:
                 all_language_probs = [(token[2:-2], prob) for (token, prob) in results]
                 filtered_language_probs = all_language_probs
                 if lang_filter:
-                    filtered_language_probs = [p for p in all_language_probs
-                                               if p[0] in lang_filter]
+                    supported_languages = set(_LANGUAGE_CODES)
+                    invalid_languages = sorted(
+                        language_code
+                        for language_code in set(lang_filter)
+                        if language_code not in supported_languages
+                    )
+                    if invalid_languages:
+                        raise ValueError(
+                            "lang_filter contains unsupported language codes: %s"
+                            % ", ".join(invalid_languages)
+                        )
+
+                    filtered_language_probs = [
+                        p for p in all_language_probs if p[0] in lang_filter
+                    ]
+                    if not filtered_language_probs:
+                        raise ValueError(
+                            "lang_filter removed all detected language candidates: %s"
+                            % ", ".join(lang_filter)
+                        )
                 # Get top language token and probability
                 language, language_probability = filtered_language_probs[0]
 


### PR DESCRIPTION
This is an incomplete PR intended to start on addressing issues semi-related to #184.

The `multilingual_input` option controls whether multiple languages should be expected in the input stream.  If False (the backwards compatible default), only one language is expected, and it will be either the one specified by the client, or the first one heard if none was specified by the client.  If True, the language can change throughout the stream, and for transcription, this will result in a multilingual text.  Notifications will be sent to the client whenever a language change is detected.  If the pauses between utterances in different languages are not long enough, the transcript boundaries may be incorrect, i.e. the first sentence in the new language may be incorrectly transcribed in the previous language.  This seems currently unavoidable due to the way the last work-in-progress segment gets reprocessed.

The `lang_filter` option allows the client to restrict the candidate set of languages for which to listen.  This may be useful regardless of the `multilingual_input` setting, e.g. at the beginning of the input where the actual language may be incorrectly detected initially.  If not set (the backwards compatible default), all known languages are listened for.

If there's interest in adding these, I can propagate them to the TensorRT code as well.  I'm not sure how to add tests since that would require using a large multilingual model (we would also need to add some multilingual samples, which might be useful anyway).
