### PR TITLE
fix: limit CPU usage for VAD onnxruntime inference session by setting…

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,13 @@ python3 run_server.py -p 9090 \
                       -trt /home/TensorRT-LLM/examples/whisper/whisper_small \
                       -m
 ```
-
+#### Controlling OpenMP Threads
+To control the number of threads used by OpenMP, you can set the `OMP_NUM_THREADS` environment variable. This is useful for managing CPU resources and ensuring consistent performance. If not specified, `OMP_NUM_THREADS` is set to `1` by default. You can change this by using the `--omp_num_threads` argument:
+```bash
+python3 run_server.py --port 9090 \
+                      --backend faster_whisper \
+                      --omp_num_threads 4
+```
 
 ### Running the Client
 - Initializing the client:

--- a/run_server.py
+++ b/run_server.py
@@ -1,5 +1,5 @@
 import argparse
-from whisper_live.server import TranscriptionServer
+import os
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -21,12 +21,20 @@ if __name__ == "__main__":
     parser.add_argument('--trt_multilingual', '-m',
                         action="store_true",
                         help='Boolean only for TensorRT model. True if multilingual.')
+    parser.add_argument('--omp_num_threads', '-omp',
+                        type=int,
+                        default=1,
+                        help="Number of threads to use for OpenMP")
     args = parser.parse_args()
 
     if args.backend == "tensorrt":
         if args.trt_model_path is None:
             raise ValueError("Please Provide a valid tensorrt model path")
 
+    if "OMP_NUM_THREADS" not in os.environ:
+        os.environ["OMP_NUM_THREADS"] = str(args.omp_num_threads)
+
+    from whisper_live.server import TranscriptionServer
     server = TranscriptionServer()
     server.run(
         "0.0.0.0",


### PR DESCRIPTION
This PR introduces an enhancement to control the number of threads used by OpenMP via the OMP_NUM_THREADS environment variable, which by default is set to `1` and can also be controlled via a command-line argument.

![Screenshot from 2024-05-24 14-39-12](https://github.com/collabora/WhisperLive/assets/39617050/716377de-b113-42c0-b830-0563eabf0741)

**ONNX Runtime and OpenMP**
`onnxruntime` uses `OpenMP` for parallelism to improve performance on multi-core systems. By setting `OMP_NUM_THREADS`, we can control the number of threads used during the execution of ONNX models, ensuring efficient resource utilization and predictable performance.

Fixes https://github.com/collabora/WhisperLive/issues/201
