### PR TITLE
Add dockerfile for tensorrt build

### DIFF
--- a/docker/Dockerfile.tensorrt
+++ b/docker/Dockerfile.tensorrt
@@ -1,0 +1,42 @@
+FROM python:3.10-bookworm
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# install libs required for pyaudio and tensorrt
+RUN apt update && apt install -y openmpi-bin libopenmpi-dev portaudio19-dev ffmpeg wget && apt-get clean && rm -rf /var/lib/apt/lists/*
+# update pip to support for whl.metadata -> less downloading
+RUN pip install --no-cache-dir -U "pip>=24"
+# install tensorrt wheels from nvidia
+RUN pip install --no-cache-dir tensorrt_llm==0.7.1 -U --extra-index-url https://pypi.nvidia.com
+# install package required by tensorrt for monitoring the device memory usage
+RUN pip install --no-cache-dir pynvml>=11.5.0
+# install specific torch versions, overwriting the torch version installed before
+# see workaround https://github.com/NVIDIA/TensorRT-LLM/issues/808#issuecomment-1880603548
+RUN pip install --no-cache-dir torch==2.1.0 torchvision==0.16.0 torchaudio==2.1.0 --index-url https://download.pytorch.org/whl/cu121
+
+# add TensorRT LLM example files, i.e. the script to compile the whisper model
+RUN wget https://github.com/NVIDIA/TensorRT-LLM/archive/refs/tags/v0.7.1.zip -O /v0.7.1.zip && unzip /v0.7.1.zip 'TensorRT-LLM-0.7.1/examples/*' && rm /v0.7.1.zip
+
+# create a working directory
+RUN mkdir /app
+WORKDIR /app
+
+# install the requirements for running the whisper-live server
+COPY requirements/server.txt /app/
+RUN pip install --no-cache-dir -r server.txt && rm server.txt
+
+# this resolves OSError: libnccl.so.2: cannot open shared object file: No such file or directory
+ENV LD_LIBRARY_PATH="/usr/local/lib/python3.10/site-packages/nvidia/nccl/lib"
+
+# install assets
+COPY assets /app/assets
+RUN wget https://raw.githubusercontent.com/openai/whisper/main/whisper/assets/mel_filters.npz -O /app/assets/mel_filters.npz
+RUN mkdir -p /root/.cache/whisper-live/
+RUN wget https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx -O /root/.cache/whisper-live/silero_vad.onnx
+
+# add the actual application code
+COPY whisper_live /app/whisper_live
+COPY run_server.py /app
+
+# You will have to add --trt_model_path /models/yourmodel and --trt_multilingual if you use a multilingual model
+CMD ["python", "run_server.py", "--backend", "tensorrt"]


### PR DESCRIPTION
## Notes

- The image assumes you have a trt engine lying around in some folder that you can mount into the docker image.
- Alternatively, you can compile a whisper model to an trt engine using this model. See howto below.
- I'm not super happy with the series of pip install, especially the workaround with the double torch install. A good next step would be to provide a requirements.txt for tensorrt-servers. That would define which packages to take from which index url and we could also exclude the installation of the deps of fasterwhisper.
- It is to be tested, which architectures can be served with this. For me it worked on a RTX 3090, and I'm about to test it on a A5000 and RTX 4000.
- TensorRT is allocating a lot of VRAM for the kv cache, more than I like (goes up to 17gb). I'm working on a way to configure that.

## Size

The resulting docker image is considerably smaller than the existing one.

```
REPOSITORY                        TAG       IMAGE ID       CREATED         SIZE
wl-new                            0.4.1-trt 54891a4d1b98   11 hours ago    14.5GB
ghcr.io/collabora/whisperbot-base latest    ef3dd12abc9a   4 months ago    25.1GB
```

## How to use

### Step 1: build the docker image
```
docker build -t wl-new:0.4.1-trt -f docker/Dockerfile.tensorrt .
```

### Step 2: run the image once to compile the tensor rt engine
```
mkdir models
docker run -v ./models:/models --rm --runtime=nvidia --gpus all -p 9090:9090 --entrypoint /bin/bash -it wl-new:0.4.1-trt

.. within the image ...

# diagnostics
python --version
python -c "import torch; print('Torch version:',torch.__version__); print('Cuda available:',torch.cuda.is_available())"
python -c "import tensorrt as trt; print('TensorRT version:',trt.__version__)"
python -c "import tensorrt_llm; print('TensorRT LLM',tensorrt_llm.__version__)"

# download the whisper model and compile it to a tensor rt engine
cd /TensorRT-LLM-0.7.1/examples/whisper/
wget --directory-prefix=assets https://openaipublic.azureedge.net/main/whisper/models/e5b1a55b89c1367dacf97e3e19bfd829a01529dbfdeefa8caeb59b3f1b81dadb/large-v3.pt
python3 build.py --output_dir /models/whisper_large_v3 --use_gpt_attention_plugin --use_gemm_plugin --use_layernorm_plugin  --use_bert_attention_plugin
```

### Step 3: run the service with the model

```
docker run -v ./models:/models --rm --runtime=nvidia --gpus all -p 9090:9090 wl-new:0.4.1-trt python3 run_server.py --backend tensorrt --trt_model_path /models/whisper_large_v3 --trt_multilingual
```
