### PR TITLE
Expose the srt file location of Transcription client

### DIFF
--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -642,6 +642,7 @@ class TranscriptionClient(TranscriptionTeeClient):
         translate (bool, optional): Indicates whether translation tasks are required (default is False).
         save_output_recording (bool, optional): Indicates whether to save recording from microphone.
         output_recording_filename (str, optional): File to save the output recording.
+        output_transcription_path (str, optional): File to save the output transcription.
 
     Attributes:
         client (Client): An instance of the underlying Client class responsible for handling the WebSocket connection.
@@ -662,11 +663,14 @@ class TranscriptionClient(TranscriptionTeeClient):
         model="small",
         use_vad=True,
         save_output_recording=False,
-        output_recording_filename="./output_recording.wav"
+        output_recording_filename="./output_recording.wav",
+        output_transcription_path="./output.srt"
     ):
-        self.client = Client(host, port, lang, translate, model, srt_file_path="output.srt", use_vad=use_vad)
+        self.client = Client(host, port, lang, translate, model, srt_file_path=output_transcription_path, use_vad=use_vad)
         if save_output_recording and not output_recording_filename.endswith(".wav"):
             raise ValueError(f"Please provide a valid `output_recording_filename`: {output_recording_filename}")
+        if not output_transcription_path.endswith(".srt"):
+            raise ValueError(f"Please provide a valid `output_transcription_path`: {output_transcription_path}. The file extension should be `.srt`.")
         TranscriptionTeeClient.__init__(
             self,
             [self.client],


### PR DESCRIPTION
## Description
This pull request addresses issue #183. The feature request is to customize the location of the client transcription.

## Changes Made
Added an argument to TranscriptionClient to specify the location where the transcription file should be saved.

## Example Code
```python
from whisper_live.client import TranscriptionClient

client = TranscriptionClient(
    "localhost",
    9090,
    lang="en",
    translate=False,
    model="small",
    use_vad=False,
    output_transcription_path="my_customized_output.srts"    # Specify the location of transcription
)

client(
    hls_url="http://as-hls-ww-live.akamaized.net/pool_904/live/ww/bbc_1xtra/bbc_1xtra.isml/bbc_1xtra-audio%3d96000.norewind.m3u8")
```

## Issue Reference
Fixes #183
