### PR TITLE
Pin silero VAD onnx model version to v4.0

### DIFF
--- a/requirements/server.txt
+++ b/requirements/server.txt
@@ -10,3 +10,4 @@ ffmpeg-python
 scipy
 jiwer
 evaluate
+numpy<2

--- a/whisper_live/vad.py
+++ b/whisper_live/vad.py
@@ -94,7 +94,7 @@ class VoiceActivityDetection():
         return stacked.cpu()
 
     @staticmethod
-    def download(model_url="https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx"):
+    def download(model_url="https://github.com/snakers4/silero-vad/raw/v4.0/files/silero_vad.onnx"):
         target_dir = os.path.expanduser("~/.cache/whisper-live/")
 
         # Ensure the target directory exists


### PR DESCRIPTION
https://github.com/snakers4/silero-vad relased a new version, which breaks for WhisperLive. So, for a quick fix, pinning version to v4.0