### PR TITLE
Initial_prompt easily accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ client = TranscriptionClient(
   use_vad=False,
   save_output_recording=True,                         # Only used for microphone input, False by Default
   output_recording_filename="./output_recording.wav"  # Only used for microphone input
+  options={
+    'initial_prompt': None,                           #To add context replace None with any context for the model like this: 'Jane Doe context'
+  }
 )
 ```
 It connects to the server running on localhost at port 9090. Using a multilingual model, language for the transcription will be automatically detected. You can also use the language option to specify the target language for the transcription, in this case, English ("en"). The translate option should be set to `True` if we want to translate from the source language to English and `False` if we want to transcribe in the source language.

--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -30,7 +30,8 @@ class Client:
         model="small",
         srt_file_path="output.srt",
         use_vad=True,
-        log_transcription=True
+        log_transcription=True,
+        options=None
     ):
         """
         Initializes a Client instance for audio recording and streaming to a server.
@@ -59,6 +60,7 @@ class Client:
         self.last_segment = None
         self.last_received_segment = None
         self.log_transcription = log_transcription
+        self.options = options
 
         if translate:
             self.task = "translate"
@@ -199,7 +201,8 @@ class Client:
                     "language": self.language,
                     "task": self.task,
                     "model": self.model,
-                    "use_vad": self.use_vad
+                    "use_vad": self.use_vad,
+                    "options": self.options
                 }
             )
         )
@@ -681,8 +684,9 @@ class TranscriptionClient(TranscriptionTeeClient):
         output_recording_filename="./output_recording.wav",
         output_transcription_path="./output.srt",
         log_transcription=True,
+        options=None,
     ):
-        self.client = Client(host, port, lang, translate, model, srt_file_path=output_transcription_path, use_vad=use_vad, log_transcription=log_transcription)
+        self.client = Client(host, port, lang, translate, model, srt_file_path=output_transcription_path, use_vad=use_vad, log_transcription=log_transcription, options=options)
         if save_output_recording and not output_recording_filename.endswith(".wav"):
             raise ValueError(f"Please provide a valid `output_recording_filename`: {output_recording_filename}")
         if not output_transcription_path.endswith(".srt"):

--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -31,7 +31,7 @@ class Client:
         srt_file_path="output.srt",
         use_vad=True,
         log_transcription=True,
-        options=None
+        options=None,
         max_clients=4,
         max_connection_time=600,
     ):
@@ -207,7 +207,7 @@ class Client:
                     "task": self.task,
                     "model": self.model,
                     "use_vad": self.use_vad,
-                    "options": self.options
+                    "options": self.options,
                     "max_clients": self.max_clients,
                     "max_connection_time": self.max_connection_time,
                 }

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -191,8 +191,8 @@ class TranscriptionServer:
                 task=options["task"],
                 client_uid=options["uid"],
                 model=options["model"],
-                initial_prompt=options.get("initial_prompt"),
-                vad_parameters=options.get("vad_parameters"),
+                initial_prompt=options["options"].get("initial_prompt"),
+                vad_parameters=options["options"].get("vad_parameters"),
                 use_vad=self.use_vad,
                 single_model=self.single_model,
             )


### PR DESCRIPTION
Made initial_prompt more easily accessible to be able to give context.
Fixed how the options.get is used.
Client now contains a parameter, which is now also described in the readme.
Only tested with faster_whisper, not TensorRT.