### PR TITLE
Fix requirements & tests for py38

### DIFF
--- a/requirements/server.txt
+++ b/requirements/server.txt
@@ -10,3 +10,4 @@ jiwer
 evaluate
 numpy<2
 openai-whisper==20240930
+tokenizers==0.20.3


### PR DESCRIPTION
Latest version of tokenizers==0.21.0 doesnt support python 3.8 so, pinning `tokenizers==0.20.3`