### PR TITLE
Set docker tesnorrt job timeout to 60 mins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
   
   build-and-push-docker-tensorrt:
     needs: [run-tests, check-code-format]
-    timeout-minutes: 20
+    timeout-minutes: 60
     runs-on: ubuntu-22.04
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
     steps:


### PR DESCRIPTION
Tensorrt docker image building fails in ci because of timeout being set to 20 minutes. This PR sets the timeout to 60 minutes.