### PR TITLE
Revert to 12.4.1 base image

### DIFF
--- a/docker/Dockerfile.tensorrt
+++ b/docker/Dockerfile.tensorrt
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.5.1-runtime-ubuntu22.04 AS base
+FROM nvidia/cuda:12.4.1-base-ubuntu22.04 AS base
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Reduce the size of docker image to be able to build & push the image to github container registery.