### PR TITLE
Fix typo in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "soundfile",
         "tokenizers==0.20.3",
         "librosa",
-        "numpy==1.26.4"
+        "numpy==1.26.4",
         "openvino",
         "openvino-genai",
         "openvino-tokenizers",


### PR DESCRIPTION
Add ',' after `numpy` in `install_requires` 