### PR TITLE
fix: pin NumPy dependency to <2.0 to avoid C-API errors with NumPy 2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "soundfile",
         "tokenizers==0.20.3",
         "librosa",
-        "numpy==1.26.4",
+        "numpy<2.0",
         "openvino",
         "openvino-genai",
         "openvino-tokenizers",


### PR DESCRIPTION
This is to solve issue #231. 

## To Reproduce:
```
> py -3.11 -m venv .venv && . .venv./Scripts/activate
> pip install whisper-live
> python run_server.py --port 9090 --backend faster_whisper
```

## Error:
```
> python run_server.py --port 9090 --backend faster_whisper

A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.2.4 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.

Traceback (most recent call last):
  File "run_server.py", line 40, in <module>
    from whisper_live.server import TranscriptionServer
  File "server.py", line 13, in <module>
    from whisper_live.vad import VoiceActivityDetector
  File "vad.py", line 5, in <module>
    import onnxruntime
  File "__init__.py", line 23, in <module>
    from onnxruntime.capi._pybind_state import ExecutionMode  # noqa: F401
  File "_pybind_state.py", line 32, in <module>
    from .onnxruntime_pybind11_state import *  # noqa
AttributeError: _ARRAY_API not found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "run_server.py", line 40, in <module>
    from whisper_live.server import TranscriptionServer
  File "server.py", line 13, in <module>
    from whisper_live.vad import VoiceActivityDetector
  File "vad.py", line 5, in <module>
    import onnxruntime
  File "__init__.py", line 57, in <module>
    raise import_capi_exception
ImportError: _ARRAY_API not found
```

## Workaround:
I had to downgrade to `numpy<2.0` for the server to start successfully.
```
> pip uninstall -y numpy
> pip install "numpy<2.0"
```

## Suggestion:
The error suggests to change the `numpy` version in `setup.py` as shown below:
```
-    "numpy==1.26.4",
+    "numpy<2.0",
```
This approach would avoid pip installing NumPy 2.x.

## Source
https://stackoverflow.com/a/78636964