### PR TITLE
Resolve daemon warnings for threading methods

### DIFF
--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -94,7 +94,7 @@ class Client:
 
         # start websocket client in a thread
         self.ws_thread = threading.Thread(target=self.client_socket.run_forever)
-        self.ws_thread.setDaemon(True)
+        self.ws_thread.daemon = True
         self.ws_thread.start()
 
         self.transcript = []


### PR DESCRIPTION
# PR Summary
This small PR resolve the deprecation warnings of daemon for threading methods:
```python
./home/runner/work/WhisperLive/WhisperLive/whisper_live/client.py:97: DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead
```