### PR TITLE
Add: support for secure WebSocket (WSS) connections

### DIFF
--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -30,6 +30,7 @@ class Client:
         model="small",
         srt_file_path="output.srt",
         use_vad=True,
+        use_wss=False,
         log_transcription=True,
         max_clients=4,
         max_connection_time=600,
@@ -72,6 +73,7 @@ class Client:
         self.server_error = False
         self.srt_file_path = srt_file_path
         self.use_vad = use_vad
+        self.use_wss = use_wss
         self.last_segment = None
         self.last_received_segment = None
         self.log_transcription = log_transcription
@@ -88,7 +90,8 @@ class Client:
         self.audio_bytes = None
 
         if host is not None and port is not None:
-            socket_url = f"ws://{host}:{port}"
+            socket_protocol = 'wss' if self.use_wss else "ws"
+            socket_url = f"{socket_protocol}://{host}:{port}"
             self.client_socket = websocket.WebSocketApp(
                 socket_url,
                 on_open=lambda ws: self.on_open(ws),
@@ -721,6 +724,7 @@ class TranscriptionClient(TranscriptionTeeClient):
         translate=False,
         model="small",
         use_vad=True,
+        use_wss=False,
         save_output_recording=False,
         output_recording_filename="./output_recording.wav",
         output_transcription_path="./output.srt",

--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -745,6 +745,7 @@ class TranscriptionClient(TranscriptionTeeClient):
             model,
             srt_file_path=output_transcription_path,
             use_vad=use_vad,
+            use_wss=use_wss,
             log_transcription=log_transcription,
             max_clients=max_clients,
             max_connection_time=max_connection_time,


### PR DESCRIPTION
## Description
This PR adds support for secure WebSocket connections (WSS) to the whisper_live client. Based on #372 

## Changes

Added a new use_wss parameter (default: False) to the Client class constructor
Modified the WebSocket URL construction to use either ws:// or wss:// protocol prefix based on the use_wss setting
Propagated the use_wss parameter through the TranscriptionClient class constructor

## Approach
This implementation uses a boolean flag (use_wss) rather than inferring the protocol from the port number as proposed in PR #308. This approach has several advantages:

- WSS can run on any port, not just 443. Many deployments use non-standard ports like 8443 or 9443 for secure WebSockets.
- Users can explicitly choose their preferred protocol regardless of port number.
- Works with various proxy and load balancer configurations where the external port might differ from the internal port.
- Defaults to False so existing code continues to work without changes.
Special case handling: Supports unusual configurations where WS might run on port 443 or WSS on standard WS ports.

## Improvement over PR #308
The implementation in PR #308 assumes WSS is only used when the port is 443, which limits flexibility. This PR takes a more general approach by:

Not hardcoding protocol choices based on port numbers
Giving developers explicit control over the protocol
Supporting all valid WSS configurations, not just those on port 443
Maintaining the same backward compatibility

## Usage
Users can now enable secure WebSocket connections by setting use_wss=True when initializing a client:
python# Create a client with secure WebSocket connection
```python
client = TranscriptionClient(
    host="example.com", 
    port=443,  # Can be any port where WSS is configured
    use_wss=True
)
```
