### PR TITLE
feat: support HuggingFace model IDs for faster_whisper_custom_model_path

### DIFF
--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -414,7 +414,8 @@ class TranscriptionServer:
         self.cache_path = cache_path
         self.client_manager = ClientManager(max_clients, max_connection_time)
         if faster_whisper_custom_model_path is not None and not os.path.exists(faster_whisper_custom_model_path):
-            raise ValueError(f"Custom faster_whisper model '{faster_whisper_custom_model_path}' is not a valid path.")
+            if "/" not in faster_whisper_custom_model_path:
+                raise ValueError(f"Custom faster_whisper model '{faster_whisper_custom_model_path}' is not a valid path or HuggingFace model.")
         if whisper_tensorrt_path is not None and not os.path.exists(whisper_tensorrt_path):
             raise ValueError(f"TensorRT model '{whisper_tensorrt_path}' is not a valid path.")
         if single_model:


### PR DESCRIPTION
Previously, the server only accepted local file paths for custom Faster Whisper models. This change allows passing HuggingFace repo IDs which are automatically downloaded and converted to CTranslate2 format by the backend if not already in CTranslate2 format.

Should Close #410 and #404 