### PR TITLE
feat: add plugin architecture for custom post-processing pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+whisper_env
+__pycache__
+*.srt
+*.wav

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ input from microphone and pre-recorded audio files.
 - [Getting Started](#getting-started)
 - [Running the Server](#running-the-server)
 - [Running the Client](#running-the-client)
+- [Advanced Features](#advanced-features)
+  - [Word-Level Timestamps](#word-level-timestamps)
+  - [Custom Vocabulary / Hotwords](#custom-vocabulary--hotwords)
+  - [Speaker Diarization](#speaker-diarization)
+  - [Authentication](#authentication)
+  - [Rate Limiting](#rate-limiting)
+  - [Auto-Reconnect](#auto-reconnect)
+  - [Batch Inference](#batch-inference)
+  - [Raw PCM Input](#raw-pcm-input)
 - [Browser Extensions](#browser-extensions)
 - [Whisper Live Server in Docker](#whisper-live-server-in-docker)
 - [Future Work](#future-work)
@@ -185,6 +194,101 @@ client(rtsp_url="rtsp://admin:admin@192.168.0.1/rtsp")
 ```python
 client(hls_url="http://as-hls-ww-live.akamaized.net/pool_904/live/ww/bbc_1xtra/bbc_1xtra.isml/bbc_1xtra-audio%3d96000.norewind.m3u8")
 ```
+
+## Browser Extensions
+
+### Advanced Features
+
+#### Word-Level Timestamps
+Enable per-word timing and confidence scores in transcription segments:
+```python
+client = TranscriptionClient(
+  "localhost", 9090,
+  word_timestamps=True,
+)
+```
+When enabled, each segment in the WebSocket response includes a `words` array:
+```json
+{
+  "segments": [{
+    "start": "0.000", "end": "2.500", "text": "Hello world",
+    "words": [
+      {"word": "Hello", "start": "0.000", "end": "0.800", "probability": 0.95},
+      {"word": " world", "start": "0.900", "end": "2.500", "probability": 0.88}
+    ]
+  }]
+}
+```
+
+#### Custom Vocabulary / Hotwords
+Boost recognition of specific terms (product names, acronyms, domain jargon):
+```python
+client = TranscriptionClient(
+  "localhost", 9090,
+  hotwords="WhisperLive,TensorRT,OpenVINO",
+)
+```
+The `hotwords` parameter is a comma-separated string passed directly to faster-whisper's keyword boosting. Also available in the REST API via the `hotwords` form field.
+
+#### Speaker Diarization
+Real-time speaker identification using pyannote.audio embeddings (optional dependency):
+```bash
+pip install pyannote.audio
+```
+```python
+client = TranscriptionClient(
+  "localhost", 9090,
+  enable_diarization=True,
+  max_speakers=4,
+)
+```
+When enabled, completed segments include a `speaker` field:
+```json
+{"start": "0.000", "end": "2.500", "text": "Hello", "speaker": "SPEAKER_00", "completed": true}
+```
+Diarization uses online cosine-similarity clustering of speaker embeddings. If `pyannote.audio` is not installed, the server logs a warning and continues without diarization.
+
+#### Authentication
+Protect both REST API and WebSocket connections with a shared API key:
+```bash
+python3 run_server.py --port 9090 --backend faster_whisper --api_key "my-secret-key"
+```
+- **REST API**: Requires `Authorization: Bearer my-secret-key` header
+- **WebSocket**: Requires either `Authorization: Bearer my-secret-key` header or `?token=my-secret-key` query parameter
+
+Unauthenticated connections receive HTTP 401 before any GPU resources are allocated.
+
+#### Rate Limiting
+Limit REST API requests per client IP (sliding 60-second window):
+```bash
+python3 run_server.py --port 9090 --backend faster_whisper --enable_rest --rate_limit_rpm 60
+```
+Clients exceeding the limit receive HTTP 429.
+
+#### Auto-Reconnect
+Automatically reconnect when the WebSocket connection drops unexpectedly:
+```python
+client = TranscriptionClient(
+  "localhost", 9090,
+  max_retries=5,    # Retry up to 5 times
+  retry_delay=3,    # Wait 3 seconds between retries
+)
+```
+Reconnection does not trigger if the server explicitly rejected the connection (server error).
+
+#### Batch Inference
+Batch multiple client sessions into single GPU calls for higher throughput:
+```bash
+python3 run_server.py --port 9090 --backend faster_whisper \
+  --batch_inference --batch_max_size 8 --batch_window_ms 50
+```
+
+#### Raw PCM Input
+Accept raw PCM int16 audio from clients (useful for embedded devices):
+```bash
+python3 run_server.py --port 9090 --backend faster_whisper --raw_pcm_input
+```
+Audio is automatically normalized to float32 range [-1.0, 1.0].
 
 ## Browser Extensions
 - Run the server with your desired backend as shown [here](https://github.com/collabora/WhisperLive?tab=readme-ov-file#running-the-server).

--- a/README.md
+++ b/README.md
@@ -349,6 +349,9 @@ Refer to [`ios-client`](https://github.com/collabora/WhisperLive/tree/main/Audio
 We are available to help you with both Open Source and proprietary AI projects. You can reach us via the Collabora website or [vineet.suryan@collabora.com](mailto:vineet.suryan@collabora.com) and [marcus.edel@collabora.com](mailto:marcus.edel@collabora.com).
 
 
+## Scaling & Deployment
+For multi-GPU deployment, load balancing, Kubernetes, and Prometheus monitoring, see the [Scaling Guide](docs/SCALING.md).
+
 ## Citations
 ```bibtex
 @article{Whisper

--- a/client_oldapi.py
+++ b/client_oldapi.py
@@ -1,0 +1,25 @@
+import sys
+from whisper_live.client import TranscriptionClient
+
+if len(sys.argv) < 2:
+    print("Usage: python transcribe_file.py <path_to_audio_file>")
+    sys.exit(1)
+
+audio_file = sys.argv[1]
+
+client = TranscriptionClient(
+    "localhost",
+    9090,
+    lang="en",
+    translate=False,
+    model="small",  # also support hf_model => `Systran/faster-whisper-small`
+    use_vad=False,
+    save_output_recording=True,  # Only used for microphone input, False by Default
+    output_recording_filename="./output_recording.wav",  # Only used for microphone input
+    mute_audio_playback=False,  # Only used for file input, False by Default
+    enable_translation=True,
+    target_language="hi",
+)
+
+# Transcribe the offline audio file
+client(audio_file)

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -1,0 +1,306 @@
+# Horizontal Scaling & Deployment Guide
+
+This document covers strategies for deploying WhisperLive across multiple GPU nodes behind a load balancer.
+
+## Architecture Overview
+
+```
+                    ┌──────────────┐
+                    │   Clients    │
+                    └──────┬───────┘
+                           │
+                    ┌──────▼───────┐
+                    │ Load Balancer│
+                    │ (nginx/HAProxy)
+                    └──────┬───────┘
+                           │
+              ┌────────────┼────────────┐
+              │            │            │
+       ┌──────▼──┐  ┌──────▼──┐  ┌──────▼──┐
+       │ Node 1  │  │ Node 2  │  │ Node N  │
+       │ GPU + WS│  │ GPU + WS│  │ GPU + WS│
+       │ :9090   │  │ :9090   │  │ :9090   │
+       └─────────┘  └─────────┘  └─────────┘
+```
+
+Each node runs an independent WhisperLive server with its own GPU.
+
+## Load Balancer Configuration
+
+### WebSocket Sticky Sessions
+
+WebSocket connections are stateful — a client must stay connected to the same backend node for the duration of the session. Use **sticky sessions** (session affinity) in your load balancer.
+
+#### nginx
+
+```nginx
+upstream whisperlive {
+    ip_hash;  # sticky sessions based on client IP
+    server node1:9090;
+    server node2:9090;
+    server node3:9090;
+}
+
+server {
+    listen 443 ssl;
+    server_name transcribe.example.com;
+
+    ssl_certificate     /etc/ssl/cert.pem;
+    ssl_certificate_key /etc/ssl/key.pem;
+
+    location / {
+        proxy_pass http://whisperlive;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+}
+```
+
+#### HAProxy
+
+```haml
+frontend ws_front
+    bind *:9090
+    default_backend ws_back
+
+backend ws_back
+    balance source          # sticky sessions by source IP
+    timeout server 3600s
+    timeout tunnel 3600s
+    server node1 10.0.0.1:9090 check
+    server node2 10.0.0.2:9090 check
+    server node3 10.0.0.3:9090 check
+```
+
+### REST API (Stateless)
+
+The REST `/v1/audio/transcriptions` endpoint is stateless and can use round-robin:
+
+```nginx
+upstream whisperlive_rest {
+    least_conn;
+    server node1:8080;
+    server node2:8080;
+    server node3:8080;
+}
+
+location /v1/ {
+    proxy_pass http://whisperlive_rest;
+}
+```
+
+## Docker Compose (Multi-Node)
+
+```yaml
+version: "3.8"
+
+services:
+  whisperlive-1:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.gpu
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0"]
+              capabilities: [gpu]
+    ports:
+      - "9091:9090"
+    command: >
+      python run_server.py
+        --port 9090
+        --backend faster_whisper
+        --faster_whisper_custom_model_path large-v3
+        --metrics_port 9100
+
+  whisperlive-2:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.gpu
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["1"]
+              capabilities: [gpu]
+    ports:
+      - "9092:9090"
+    command: >
+      python run_server.py
+        --port 9090
+        --backend faster_whisper
+        --faster_whisper_custom_model_path large-v3
+        --metrics_port 9100
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - whisperlive-1
+      - whisperlive-2
+```
+
+## Kubernetes Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whisperlive
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: whisperlive
+  template:
+    metadata:
+      labels:
+        app: whisperlive
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9100"
+    spec:
+      containers:
+        - name: whisperlive
+          image: your-registry/whisperlive:latest
+          ports:
+            - containerPort: 9090
+              name: websocket
+            - containerPort: 8080
+              name: rest
+            - containerPort: 9100
+              name: metrics
+          args:
+            - "python"
+            - "run_server.py"
+            - "--port"
+            - "9090"
+            - "--backend"
+            - "faster_whisper"
+            - "--metrics_port"
+            - "9100"
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              nvidia.com/gpu: "1"
+              memory: "8Gi"
+              cpu: "4"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whisperlive
+spec:
+  type: ClusterIP
+  sessionAffinity: ClientIP  # sticky sessions for WebSocket
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 3600
+  ports:
+    - name: websocket
+      port: 9090
+      targetPort: 9090
+    - name: rest
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: whisperlive
+```
+
+## Prometheus Monitoring
+
+With `--metrics_port 9100`, each node exposes metrics at `http://<node>:9100/metrics`.
+
+### Prometheus scrape config
+
+```yaml
+scrape_configs:
+  - job_name: whisperlive
+    static_configs:
+      - targets:
+          - node1:9100
+          - node2:9100
+          - node3:9100
+```
+
+### Key metrics to monitor
+
+| Metric | Description | Alert Threshold |
+|--------|-------------|-----------------|
+| `whisperlive_connections_active` | Current WebSocket sessions per node | > 80% of `--max_clients` |
+| `whisperlive_transcription_latency_seconds` | Per-chunk transcription time | p99 > 2s |
+| `whisperlive_audio_processed_seconds_total` | Total audio throughput | Rate drop > 50% |
+| `whisperlive_errors_total` | Error count by type | Rate > 5/min |
+| `whisperlive_connections_rejected_total` | Rejected connections | Rate > 0 |
+
+### Grafana Dashboard
+
+Import the Prometheus metrics above into Grafana with panels for:
+- Active connections per node (gauge)
+- Transcription latency heatmap (histogram)
+- Audio throughput rate (counter rate)
+- Error rate by type (counter rate)
+- Connection rejection rate by reason (counter rate)
+
+## Capacity Planning
+
+### Per-Node Estimates (faster-whisper, large-v3)
+
+| GPU | Concurrent Streams | Real-Time Factor | VRAM Used |
+|-----|--------------------|-------------------|-----------|
+| RTX 3090 (24GB) | 5–8 | ~0.1x | ~6GB |
+| A100 (40GB) | 15–25 | ~0.05x | ~8GB |
+| A100 (80GB) | 30–50 | ~0.05x | ~8GB |
+| H100 (80GB) | 40–60 | ~0.03x | ~8GB |
+
+*Estimates vary based on audio complexity, VAD filtering, and model size.*
+
+### Scaling Formula
+
+```
+nodes_needed = ceil(peak_concurrent_streams / streams_per_node)
+```
+
+Add 20–30% headroom for burst capacity.
+
+## Health Checks
+
+Use the REST API for health probing:
+
+```bash
+# Simple liveness check
+curl http://node1:8080/v1/audio/transcriptions \
+  -F file=@/dev/null \
+  -F model=whisper-1 \
+  --max-time 5
+
+# Or add a dedicated /health endpoint (recommended)
+```
+
+## Best Practices
+
+1. **Use `--single_model`** — Shares one model instance across all connections per node. Reduces VRAM usage significantly.
+
+2. **Enable batch inference** — Use `--batch_inference` with `--batch_max_size 8` to batch requests and improve GPU utilization.
+
+3. **Set `--max_clients`** — Limit concurrent connections per node to prevent OOM. Match to your GPU capacity.
+
+4. **Monitor metrics** — Use Prometheus + Grafana to track saturation and latency.
+
+5. **Use WSS (TLS)** — Terminate TLS at the load balancer, not at each node.
+
+6. **API key auth** — Use `--api_key` to protect both REST and WebSocket endpoints.
+
+7. **Rate limiting** — Use `--rate_limit_rpm` to prevent REST API abuse.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*

--- a/run_client.py
+++ b/run_client.py
@@ -33,7 +33,8 @@ if __name__ == '__main__':
                           help='Language code for transcription, e.g., "en" for English.')
     parser.add_argument('--translate', '-t',
                           action='store_true',
-                          help='Enable translation of the transcription output.')
+                          help='Use Whisper built-in translation to English (sets task=translate). '
+                              'For any-to-any translation, use --enable_translation instead.')
     parser.add_argument('--mute_audio_playback', '-a',
                           action='store_true',
                           help='Mute audio playback during transcription.') 
@@ -42,7 +43,7 @@ if __name__ == '__main__':
                           help='Save the output recording, only used for microphone input.')
     parser.add_argument('--enable_translation',
                           action='store_true',
-                          help='Enable translation of the transcription output.')
+                          help='Enable any-to-any translation via M2M100 model (separate from Whisper --translate).')
     parser.add_argument('--target_language', '-tl',
                           type=str,
                           default='fr',
@@ -56,6 +57,12 @@ if __name__ == '__main__':
                           help='Number of transcript segments to display in terminal (default: 4).')
 
     args = parser.parse_args()
+
+    if args.translate and args.enable_translation:
+        print("[WARN]: Both --translate and --enable_translation are set. "
+              "--translate uses Whisper's built-in to-English translation, "
+              "while --enable_translation uses M2M100 for any-to-any. "
+              "Both will be active.")
 
     client = TranscriptionClient(
         args.server,

--- a/run_server.py
+++ b/run_server.py
@@ -84,6 +84,12 @@ if __name__ == "__main__":
         default=50,
         help='Maximum time in ms to wait for batch to fill (default: 50).'
     )
+    parser.add_argument(
+        '--raw_pcm_input',
+        action='store_true',
+        help='Expect raw PCM int16 audio from clients instead of float32. '
+             'Audio will be normalized to float32 range [-1.0, 1.0].'
+    )
     args = parser.parse_args()
 
     if args.backend == "tensorrt":
@@ -113,4 +119,5 @@ if __name__ == "__main__":
         batch_enabled=args.batch_inference,
         batch_max_size=args.batch_max_size,
         batch_window_ms=args.batch_window_ms,
+        raw_pcm_input=args.raw_pcm_input,
     )

--- a/run_server.py
+++ b/run_server.py
@@ -103,6 +103,12 @@ if __name__ == "__main__":
         default=0,
         help='Maximum REST API requests per minute per client IP. 0 = unlimited (default).'
     )
+    parser.add_argument(
+        '--metrics_port',
+        type=int,
+        default=0,
+        help='Port for Prometheus /metrics endpoint. 0 = disabled (default). Requires prometheus_client.'
+    )
     args = parser.parse_args()
 
     if args.backend == "tensorrt":
@@ -135,4 +141,5 @@ if __name__ == "__main__":
         raw_pcm_input=args.raw_pcm_input,
         api_key=args.api_key,
         rate_limit_rpm=args.rate_limit_rpm,
+        metrics_port=args.metrics_port,
     )

--- a/run_server.py
+++ b/run_server.py
@@ -90,6 +90,19 @@ if __name__ == "__main__":
         help='Expect raw PCM int16 audio from clients instead of float32. '
              'Audio will be normalized to float32 range [-1.0, 1.0].'
     )
+    parser.add_argument(
+        '--api_key',
+        type=str,
+        default=None,
+        help='Optional API key for authenticating REST API requests. '
+             'Clients must send "Authorization: Bearer <key>" header.'
+    )
+    parser.add_argument(
+        '--rate_limit_rpm',
+        type=int,
+        default=0,
+        help='Maximum REST API requests per minute per client IP. 0 = unlimited (default).'
+    )
     args = parser.parse_args()
 
     if args.backend == "tensorrt":
@@ -120,4 +133,6 @@ if __name__ == "__main__":
         batch_max_size=args.batch_max_size,
         batch_window_ms=args.batch_window_ms,
         raw_pcm_input=args.raw_pcm_input,
+        api_key=args.api_key,
+        rate_limit_rpm=args.rate_limit_rpm,
     )

--- a/tests/test_audio_intelligence.py
+++ b/tests/test_audio_intelligence.py
@@ -1,0 +1,156 @@
+import unittest
+
+from whisper_live.audio_intelligence import (
+    analyze_sentiment,
+    detect_topics,
+    extract_entities,
+    summarize,
+    analyze_transcript,
+)
+
+
+class TestAnalyzeSentiment(unittest.TestCase):
+    def test_positive(self):
+        result = analyze_sentiment("This is great and amazing work!")
+        self.assertEqual(result["label"], "positive")
+        self.assertGreater(result["score"], 0)
+        self.assertGreater(result["positive_count"], 0)
+
+    def test_negative(self):
+        result = analyze_sentiment("This is terrible and awful")
+        self.assertEqual(result["label"], "negative")
+        self.assertLess(result["score"], 0)
+        self.assertGreater(result["negative_count"], 0)
+
+    def test_neutral(self):
+        result = analyze_sentiment("The cat sat on the mat")
+        self.assertEqual(result["label"], "neutral")
+        self.assertEqual(result["score"], 0.0)
+
+    def test_mixed(self):
+        result = analyze_sentiment("It was great but also terrible")
+        self.assertIn(result["label"], ["positive", "negative", "neutral"])
+
+    def test_empty(self):
+        result = analyze_sentiment("")
+        self.assertEqual(result["label"], "neutral")
+        self.assertEqual(result["score"], 0.0)
+
+
+class TestDetectTopics(unittest.TestCase):
+    def test_basic_topics(self):
+        text = "machine learning and artificial intelligence are revolutionizing technology and machine learning is growing fast"
+        topics = detect_topics(text, top_n=3)
+        self.assertTrue(len(topics) > 0)
+        topic_words = [t["topic"] for t in topics]
+        self.assertIn("machine", topic_words)
+
+    def test_respects_top_n(self):
+        text = "apple banana cherry date elderberry fig grape apple banana cherry date"
+        topics = detect_topics(text, top_n=2, min_word_length=3)
+        self.assertLessEqual(len(topics), 2)
+
+    def test_excludes_stop_words(self):
+        text = "the the the and and and"
+        topics = detect_topics(text)
+        self.assertEqual(topics, [])
+
+    def test_min_word_length(self):
+        text = "cat dog rat bat car van bus"
+        topics = detect_topics(text, min_word_length=4)
+        self.assertEqual(topics, [])
+
+    def test_empty(self):
+        self.assertEqual(detect_topics(""), [])
+
+
+class TestExtractEntities(unittest.TestCase):
+    def test_date_mdy(self):
+        entities = extract_entities("Meeting on 12/25/2024")
+        self.assertIn("date", entities)
+
+    def test_date_named(self):
+        entities = extract_entities("Meeting on January 15, 2024")
+        self.assertIn("date", entities)
+
+    def test_time(self):
+        entities = extract_entities("Call at 3:30 PM")
+        self.assertIn("time", entities)
+
+    def test_money(self):
+        entities = extract_entities("Cost is $1,500.00")
+        self.assertIn("money", entities)
+        self.assertIn("$1,500.00", entities["money"])
+
+    def test_percentage(self):
+        entities = extract_entities("Growth of 25.5%")
+        self.assertIn("percentage", entities)
+
+    def test_url(self):
+        entities = extract_entities("Visit https://example.com for details")
+        self.assertIn("url", entities)
+
+    def test_no_entities(self):
+        self.assertEqual(extract_entities("Hello world"), {})
+
+    def test_empty(self):
+        self.assertEqual(extract_entities(""), {})
+
+    def test_multiple_types(self):
+        text = "On 01/15/2024 at 2:00 PM we spent $500 which is 10% of budget"
+        entities = extract_entities(text)
+        self.assertIn("date", entities)
+        self.assertIn("time", entities)
+        self.assertIn("money", entities)
+        self.assertIn("percentage", entities)
+
+
+class TestSummarize(unittest.TestCase):
+    def test_short_text_returned_as_is(self):
+        text = "This is short. Only two sentences."
+        result = summarize(text, num_sentences=3)
+        self.assertEqual(result, text)
+
+    def test_reduces_long_text(self):
+        sentences = [f"Sentence number {i} about topic {i % 3}." for i in range(10)]
+        text = " ".join(sentences)
+        result = summarize(text, num_sentences=3)
+        # Should have approximately 3 sentences
+        result_sentences = [s.strip() for s in result.split(".") if s.strip()]
+        self.assertLessEqual(len(result_sentences), 4)  # some tolerance for splits
+
+    def test_preserves_order(self):
+        text = "Alpha is first. Beta is second. Gamma is third. Delta is fourth. Epsilon is fifth."
+        result = summarize(text, num_sentences=2)
+        # Selected sentences should appear in original order
+        parts = result.split(".")
+        self.assertTrue(len(parts) >= 2)
+
+    def test_empty(self):
+        self.assertEqual(summarize(""), "")
+
+
+class TestAnalyzeTranscript(unittest.TestCase):
+    def test_full_pipeline(self):
+        text = "The meeting on January 15 was great. Revenue grew 25% to $1,000,000. Machine learning is amazing."
+        result = analyze_transcript(text)
+        self.assertIn("sentiment", result)
+        self.assertIn("topics", result)
+        self.assertIn("entities", result)
+        self.assertIn("summary", result)
+
+    def test_selective_analysis(self):
+        text = "Hello world."
+        result = analyze_transcript(text, sentiment=True, topics=False, entities=False, summary=False)
+        self.assertIn("sentiment", result)
+        self.assertNotIn("topics", result)
+        self.assertNotIn("entities", result)
+        self.assertNotIn("summary", result)
+
+    def test_all_disabled(self):
+        result = analyze_transcript("text", sentiment=False, topics=False, entities=False, summary=False)
+        self.assertEqual(result, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_base_backend.py
+++ b/tests/test_base_backend.py
@@ -410,5 +410,110 @@ class TestGetSegmentHelpers(unittest.TestCase):
         self.assertAlmostEqual(self.client.get_segment_start(seg), 2.0)
 
 
+class TestWordTimestamps(unittest.TestCase):
+    """Tests for word-level timestamp extraction."""
+
+    def _make_client(self, word_timestamps=False):
+        ws = MagicMock()
+        return ConcreteServeClient(
+            client_uid="wt-uid", websocket=ws, word_timestamps=word_timestamps
+        )
+
+    def _make_word(self, word, start, end, prob):
+        w = MagicMock()
+        w.word = word
+        w.start = start
+        w.end = end
+        w.probability = prob
+        return w
+
+    def _make_segment(self, text, start, end, no_speech_prob=0.0, words=None):
+        seg = MagicMock()
+        seg.text = text
+        seg.start = start
+        seg.end = end
+        seg.no_speech_prob = no_speech_prob
+        seg.words = words
+        return seg
+
+    def test_word_timestamps_disabled_by_default(self):
+        client = self._make_client()
+        self.assertFalse(client.word_timestamps)
+
+    def test_word_timestamps_enabled(self):
+        client = self._make_client(word_timestamps=True)
+        self.assertTrue(client.word_timestamps)
+
+    def test_extract_words_when_disabled(self):
+        client = self._make_client(word_timestamps=False)
+        seg = self._make_segment("hello", 0.0, 1.0, words=[self._make_word("hello", 0.0, 0.5, 0.99)])
+        result = client._extract_words(seg, 0.0)
+        self.assertIsNone(result)
+
+    def test_extract_words_when_enabled(self):
+        client = self._make_client(word_timestamps=True)
+        words = [
+            self._make_word("hello", 0.0, 0.3, 0.95),
+            self._make_word("world", 0.4, 0.8, 0.88),
+        ]
+        seg = self._make_segment("hello world", 0.0, 1.0, words=words)
+        result = client._extract_words(seg, 10.0)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["word"], "hello")
+        self.assertEqual(result[0]["start"], "10.000")
+        self.assertEqual(result[0]["end"], "10.300")
+        self.assertEqual(result[0]["probability"], 0.95)
+        self.assertEqual(result[1]["word"], "world")
+        self.assertEqual(result[1]["start"], "10.400")
+
+    def test_extract_words_no_words_on_segment(self):
+        client = self._make_client(word_timestamps=True)
+        seg = self._make_segment("hello", 0.0, 1.0, words=None)
+        result = client._extract_words(seg, 0.0)
+        self.assertIsNone(result)
+
+    def test_format_segment_without_words(self):
+        client = self._make_client()
+        seg = client.format_segment(0.0, 1.0, "hello")
+        self.assertNotIn("words", seg)
+
+    def test_format_segment_with_words(self):
+        client = self._make_client(word_timestamps=True)
+        words = [{"word": "hello", "start": "0.000", "end": "0.500", "probability": 0.95}]
+        seg = client.format_segment(0.0, 1.0, "hello", words=words)
+        self.assertIn("words", seg)
+        self.assertEqual(len(seg["words"]), 1)
+        self.assertEqual(seg["words"][0]["word"], "hello")
+
+    def test_update_segments_includes_words(self):
+        client = self._make_client(word_timestamps=True)
+        words1 = [self._make_word("hello", 0.0, 0.5, 0.9)]
+        words2 = [self._make_word("world", 0.6, 1.0, 0.85)]
+        segments = [
+            self._make_segment(" hello", 0.0, 0.5, words=words1),
+            self._make_segment(" world", 0.6, 1.0, words=words2),
+        ]
+        last = client.update_segments(segments, 2.0)
+        # First segment should be completed (in transcript) with words
+        self.assertTrue(len(client.transcript) > 0)
+        self.assertIn("words", client.transcript[-1])
+        # Last segment should be in-progress with words
+        self.assertIsNotNone(last)
+        self.assertIn("words", last)
+
+    def test_update_segments_no_words_when_disabled(self):
+        client = self._make_client(word_timestamps=False)
+        words1 = [self._make_word("hello", 0.0, 0.5, 0.9)]
+        words2 = [self._make_word("world", 0.6, 1.0, 0.85)]
+        segments = [
+            self._make_segment(" hello", 0.0, 0.5, words=words1),
+            self._make_segment(" world", 0.6, 1.0, words=words2),
+        ]
+        last = client.update_segments(segments, 2.0)
+        self.assertTrue(len(client.transcript) > 0)
+        self.assertNotIn("words", client.transcript[-1])
+        self.assertNotIn("words", last)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_base_backend.py
+++ b/tests/test_base_backend.py
@@ -1,0 +1,387 @@
+import json
+import queue
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from whisper_live.backend.base import ServeClientBase
+
+
+class ConcreteServeClient(ServeClientBase):
+    """Concrete subclass for testing the abstract base class."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.language = "en"
+
+    def transcribe_audio(self, input_sample):
+        return None
+
+    def handle_transcription_output(self, result, duration):
+        pass
+
+
+class TestServeClientBaseInit(unittest.TestCase):
+    def test_default_values(self):
+        ws = MagicMock()
+        client = ConcreteServeClient(client_uid="test-uid", websocket=ws)
+        self.assertEqual(client.client_uid, "test-uid")
+        self.assertEqual(client.send_last_n_segments, 10)
+        self.assertAlmostEqual(client.no_speech_thresh, 0.45)
+        self.assertFalse(client.clip_audio)
+        self.assertEqual(client.same_output_threshold, 10)
+        self.assertIsNone(client.frames_np)
+        self.assertAlmostEqual(client.timestamp_offset, 0.0)
+        self.assertFalse(client.exit)
+        self.assertEqual(client.transcript, [])
+
+    def test_custom_values(self):
+        ws = MagicMock()
+        q = queue.Queue()
+        client = ConcreteServeClient(
+            client_uid="uid2",
+            websocket=ws,
+            send_last_n_segments=5,
+            no_speech_thresh=0.6,
+            clip_audio=True,
+            same_output_threshold=20,
+            translation_queue=q,
+        )
+        self.assertEqual(client.send_last_n_segments, 5)
+        self.assertAlmostEqual(client.no_speech_thresh, 0.6)
+        self.assertTrue(client.clip_audio)
+        self.assertEqual(client.same_output_threshold, 20)
+        self.assertIs(client.translation_queue, q)
+
+
+class TestAddFrames(unittest.TestCase):
+    def setUp(self):
+        self.ws = MagicMock()
+        self.client = ConcreteServeClient(client_uid="test", websocket=self.ws)
+
+    def test_first_frame_initializes_buffer(self):
+        frame = np.array([0.1, 0.2, 0.3], dtype=np.float32)
+        self.client.add_frames(frame)
+        np.testing.assert_array_equal(self.client.frames_np, frame)
+
+    def test_subsequent_frames_concatenated(self):
+        frame1 = np.array([0.1, 0.2], dtype=np.float32)
+        frame2 = np.array([0.3, 0.4], dtype=np.float32)
+        self.client.add_frames(frame1)
+        self.client.add_frames(frame2)
+        expected = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)
+        np.testing.assert_array_equal(self.client.frames_np, expected)
+
+    def test_buffer_trimmed_at_45_seconds(self):
+        # 45 seconds + 1 sample at 16kHz = 720001 samples
+        self.client.frames_np = np.zeros(45 * 16000 + 1, dtype=np.float32)
+        self.client.add_frames(np.array([1.0], dtype=np.float32))
+        # after trimming 30s, buffer should be ~15s + 1 original + 1 new
+        expected_len = (45 * 16000 + 1) - (30 * 16000) + 1
+        self.assertEqual(self.client.frames_np.shape[0], expected_len)
+        self.assertAlmostEqual(self.client.frames_offset, 30.0)
+
+    def test_timestamp_offset_updated_on_trim(self):
+        self.client.frames_np = np.zeros(45 * 16000 + 1, dtype=np.float32)
+        self.client.timestamp_offset = 5.0  # behind frames_offset after trim
+        self.client.add_frames(np.array([1.0], dtype=np.float32))
+        # timestamp_offset should be bumped to at least frames_offset
+        self.assertGreaterEqual(self.client.timestamp_offset, self.client.frames_offset)
+
+
+class TestAddFramesThreadSafety(unittest.TestCase):
+    def test_concurrent_add_frames(self):
+        ws = MagicMock()
+        client = ConcreteServeClient(client_uid="test", websocket=ws)
+        errors = []
+
+        def add_many():
+            try:
+                for _ in range(100):
+                    client.add_frames(np.random.randn(160).astype(np.float32))
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=add_many) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(errors, [])
+        self.assertIsNotNone(client.frames_np)
+
+
+class TestGetAudioChunkForProcessing(unittest.TestCase):
+    def setUp(self):
+        self.ws = MagicMock()
+        self.client = ConcreteServeClient(client_uid="test", websocket=self.ws)
+
+    def test_empty_buffer_returns_empty(self):
+        self.client.frames_np = np.array([], dtype=np.float32)
+        chunk, duration = self.client.get_audio_chunk_for_processing()
+        self.assertEqual(duration, 0.0)
+        self.assertEqual(chunk.shape[0], 0)
+
+    def test_full_buffer_no_offset(self):
+        audio = np.random.randn(16000).astype(np.float32)  # 1 second
+        self.client.frames_np = audio
+        chunk, duration = self.client.get_audio_chunk_for_processing()
+        self.assertAlmostEqual(duration, 1.0)
+        np.testing.assert_array_equal(chunk, audio)
+
+    def test_with_offset(self):
+        audio = np.random.randn(32000).astype(np.float32)  # 2 seconds
+        self.client.frames_np = audio
+        self.client.timestamp_offset = 1.0  # skip first second
+        chunk, duration = self.client.get_audio_chunk_for_processing()
+        self.assertAlmostEqual(duration, 1.0)
+        self.assertEqual(chunk.shape[0], 16000)
+
+
+class TestClipAudioIfNoValidSegment(unittest.TestCase):
+    def setUp(self):
+        self.ws = MagicMock()
+        self.client = ConcreteServeClient(
+            client_uid="test", websocket=self.ws, clip_audio=True
+        )
+
+    def test_clips_when_chunk_exceeds_25s(self):
+        # 30 seconds of audio with no valid segments
+        self.client.frames_np = np.zeros(30 * 16000, dtype=np.float32)
+        self.client.timestamp_offset = 0.0
+        self.client.frames_offset = 0.0
+        self.client.clip_audio_if_no_valid_segment()
+        # offset should have advanced to leave ~5s of remaining audio
+        expected_offset = (30 * 16000 / 16000) - 5
+        self.assertAlmostEqual(self.client.timestamp_offset, expected_offset, places=1)
+
+    def test_no_clip_when_short(self):
+        self.client.frames_np = np.zeros(10 * 16000, dtype=np.float32)
+        self.client.timestamp_offset = 0.0
+        self.client.frames_offset = 0.0
+        self.client.clip_audio_if_no_valid_segment()
+        self.assertAlmostEqual(self.client.timestamp_offset, 0.0)
+
+
+class TestPrepareSegments(unittest.TestCase):
+    def setUp(self):
+        self.ws = MagicMock()
+        self.client = ConcreteServeClient(
+            client_uid="test", websocket=self.ws, send_last_n_segments=3
+        )
+
+    def test_empty_transcript_no_last(self):
+        segments = self.client.prepare_segments()
+        self.assertEqual(segments, [])
+
+    def test_empty_transcript_with_last(self):
+        last = {"start": "0.000", "end": "1.000", "text": "hello", "completed": False}
+        segments = self.client.prepare_segments(last_segment=last)
+        self.assertEqual(len(segments), 1)
+        self.assertEqual(segments[0]["text"], "hello")
+
+    def test_fewer_than_n_segments(self):
+        self.client.transcript = [
+            {"start": "0.000", "end": "1.000", "text": "a", "completed": True},
+            {"start": "1.000", "end": "2.000", "text": "b", "completed": True},
+        ]
+        segments = self.client.prepare_segments()
+        self.assertEqual(len(segments), 2)
+
+    def test_more_than_n_segments_truncated(self):
+        self.client.transcript = [
+            {"start": f"{i}.000", "end": f"{i+1}.000", "text": f"seg{i}", "completed": True}
+            for i in range(10)
+        ]
+        segments = self.client.prepare_segments()
+        self.assertEqual(len(segments), 3)
+        self.assertEqual(segments[0]["text"], "seg7")
+
+    def test_last_segment_appended(self):
+        self.client.transcript = [
+            {"start": "0.000", "end": "1.000", "text": "a", "completed": True},
+        ]
+        last = {"start": "1.000", "end": "2.000", "text": "in progress", "completed": False}
+        segments = self.client.prepare_segments(last_segment=last)
+        self.assertEqual(len(segments), 2)
+        self.assertEqual(segments[-1]["text"], "in progress")
+
+
+class TestFormatSegment(unittest.TestCase):
+    def setUp(self):
+        self.ws = MagicMock()
+        self.client = ConcreteServeClient(client_uid="test", websocket=self.ws)
+
+    def test_format(self):
+        seg = self.client.format_segment(1.234, 5.678, "hello world", completed=True)
+        self.assertEqual(seg["start"], "1.234")
+        self.assertEqual(seg["end"], "5.678")
+        self.assertEqual(seg["text"], "hello world")
+        self.assertTrue(seg["completed"])
+
+    def test_format_not_completed(self):
+        seg = self.client.format_segment(0.0, 1.0, "text")
+        self.assertFalse(seg["completed"])
+
+
+class TestSendTranscriptionToClient(unittest.TestCase):
+    def setUp(self):
+        self.ws = MagicMock()
+        self.client = ConcreteServeClient(client_uid="test-uid", websocket=self.ws)
+
+    def test_sends_json(self):
+        segments = [{"start": "0.000", "end": "1.000", "text": "hi", "completed": True}]
+        self.client.send_transcription_to_client(segments)
+        self.ws.send.assert_called_once()
+        sent = json.loads(self.ws.send.call_args[0][0])
+        self.assertEqual(sent["uid"], "test-uid")
+        self.assertEqual(len(sent["segments"]), 1)
+
+    def test_send_failure_logged_not_raised(self):
+        self.ws.send.side_effect = ConnectionError("broken pipe")
+        # should not raise
+        self.client.send_transcription_to_client([])
+
+
+class TestDisconnect(unittest.TestCase):
+    def test_sends_disconnect_message(self):
+        ws = MagicMock()
+        client = ConcreteServeClient(client_uid="uid1", websocket=ws)
+        client.disconnect()
+        sent = json.loads(ws.send.call_args[0][0])
+        self.assertEqual(sent["uid"], "uid1")
+        self.assertEqual(sent["message"], "DISCONNECT")
+
+
+class TestCleanup(unittest.TestCase):
+    def test_sets_exit_flag(self):
+        ws = MagicMock()
+        client = ConcreteServeClient(client_uid="uid1", websocket=ws)
+        self.assertFalse(client.exit)
+        client.cleanup()
+        self.assertTrue(client.exit)
+
+
+class TestUpdateSegments(unittest.TestCase):
+    """Tests for the core update_segments() logic."""
+
+    def setUp(self):
+        self.ws = MagicMock()
+        self.client = ConcreteServeClient(
+            client_uid="test",
+            websocket=self.ws,
+            no_speech_thresh=0.45,
+            same_output_threshold=3,
+        )
+        self.client.frames_np = np.zeros(16000 * 5, dtype=np.float32)
+
+    def _make_segment(self, start, end, text, no_speech_prob=0.0):
+        seg = MagicMock()
+        seg.start = start
+        seg.end = end
+        seg.text = text
+        seg.no_speech_prob = no_speech_prob
+        return seg
+
+    def test_single_segment_becomes_last(self):
+        segs = [self._make_segment(0.0, 1.0, " hello")]
+        last = self.client.update_segments(segs, duration=2.0)
+        self.assertIsNotNone(last)
+        self.assertIn("hello", last["text"])
+        self.assertFalse(last["completed"])
+        self.assertEqual(len(self.client.transcript), 0)
+
+    def test_multiple_segments_completes_all_but_last(self):
+        segs = [
+            self._make_segment(0.0, 1.0, " first"),
+            self._make_segment(1.0, 2.0, " second"),
+        ]
+        last = self.client.update_segments(segs, duration=3.0)
+        self.assertEqual(len(self.client.transcript), 1)
+        self.assertTrue(self.client.transcript[0]["completed"])
+        self.assertIn("first", self.client.transcript[0]["text"])
+        self.assertIsNotNone(last)
+        self.assertIn("second", last["text"])
+
+    def test_high_no_speech_prob_skipped(self):
+        segs = [
+            self._make_segment(0.0, 1.0, " noise", no_speech_prob=0.9),
+            self._make_segment(1.0, 2.0, " also noise", no_speech_prob=0.9),
+        ]
+        last = self.client.update_segments(segs, duration=3.0)
+        self.assertEqual(len(self.client.transcript), 0)
+        self.assertIsNone(last)
+
+    def test_segment_with_start_gte_end_skipped(self):
+        segs = [
+            self._make_segment(1.0, 0.5, " backwards"),
+            self._make_segment(1.5, 2.0, " normal"),
+        ]
+        last = self.client.update_segments(segs, duration=3.0)
+        self.assertEqual(len(self.client.transcript), 0)
+        self.assertIsNotNone(last)
+
+    def test_repeated_output_triggers_completion(self):
+        seg = self._make_segment(0.0, 1.0, " repeated")
+        for _ in range(self.client.same_output_threshold + 2):
+            last = self.client.update_segments([seg], duration=2.0)
+        # after enough repeats, should be added to transcript
+        self.assertTrue(len(self.client.transcript) >= 1)
+
+    def test_translation_queue_receives_completed(self):
+        q = queue.Queue()
+        self.client.translation_queue = q
+        segs = [
+            self._make_segment(0.0, 1.0, " first"),
+            self._make_segment(1.0, 2.0, " second"),
+        ]
+        self.client.update_segments(segs, duration=3.0)
+        self.assertFalse(q.empty())
+        item = q.get_nowait()
+        self.assertIn("first", item["text"])
+
+    def test_timestamp_offset_advances(self):
+        segs = [
+            self._make_segment(0.0, 1.0, " first"),
+            self._make_segment(1.0, 2.0, " second"),
+        ]
+        self.client.update_segments(segs, duration=3.0)
+        self.assertGreater(self.client.timestamp_offset, 0.0)
+
+
+class TestGetSegmentHelpers(unittest.TestCase):
+    def setUp(self):
+        self.ws = MagicMock()
+        self.client = ConcreteServeClient(client_uid="test", websocket=self.ws)
+
+    def test_get_segment_no_speech_prob_attr(self):
+        seg = MagicMock()
+        seg.no_speech_prob = 0.3
+        self.assertAlmostEqual(self.client.get_segment_no_speech_prob(seg), 0.3)
+
+    def test_get_segment_no_speech_prob_fallback(self):
+        seg = MagicMock(spec=[])  # no attributes
+        self.assertEqual(self.client.get_segment_no_speech_prob(seg), 0)
+
+    def test_get_segment_start_uses_start(self):
+        seg = MagicMock()
+        seg.start = 1.5
+        self.assertAlmostEqual(self.client.get_segment_start(seg), 1.5)
+
+    def test_get_segment_end_uses_end(self):
+        seg = MagicMock()
+        seg.end = 3.0
+        self.assertAlmostEqual(self.client.get_segment_end(seg), 3.0)
+
+    def test_get_segment_start_fallback_to_start_ts(self):
+        seg = MagicMock(spec=["start_ts"])
+        seg.start_ts = 2.0
+        self.assertAlmostEqual(self.client.get_segment_start(seg), 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_base_backend.py
+++ b/tests/test_base_backend.py
@@ -266,6 +266,33 @@ class TestCleanup(unittest.TestCase):
         self.assertTrue(client.exit)
 
 
+class TestTrimTranscript(unittest.TestCase):
+    def setUp(self):
+        self.ws = MagicMock()
+        self.client = ConcreteServeClient(client_uid="test", websocket=self.ws)
+
+    def test_transcript_trimmed_when_over_max(self):
+        self.client.transcript = [
+            {"start": f"{i}.000", "end": f"{i+1}.000", "text": f"seg{i}", "completed": True}
+            for i in range(self.client.MAX_TRANSCRIPT_LENGTH + 100)
+        ]
+        self.client._trim_transcript()
+        self.assertEqual(len(self.client.transcript), self.client.MAX_TRANSCRIPT_LENGTH)
+        self.assertEqual(self.client.transcript[0]["text"], "seg100")
+
+    def test_transcript_not_trimmed_when_under_max(self):
+        self.client.transcript = [
+            {"start": "0.000", "end": "1.000", "text": "a", "completed": True}
+        ]
+        self.client._trim_transcript()
+        self.assertEqual(len(self.client.transcript), 1)
+
+    def test_text_list_trimmed(self):
+        self.client.text = ["word"] * (self.client.MAX_TRANSCRIPT_LENGTH + 50)
+        self.client._trim_transcript()
+        self.assertEqual(len(self.client.text), self.client.MAX_TRANSCRIPT_LENGTH)
+
+
 class TestUpdateSegments(unittest.TestCase):
     """Tests for the core update_segments() logic."""
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -43,21 +43,20 @@ class TestClientWebSocketCommunication(BaseTestCase):
 
 class TestClientCallbacks(BaseTestCase):
     def test_on_open(self):
-        expected_message = json.dumps({
-            "uid": self.client.uid,
-            "language": self.client.language,
-            "task": self.client.task,
-            "model": self.client.model,
-            "use_vad": True,
-            "send_last_n_segments": 10,
-            "no_speech_thresh": 0.45,
-            "clip_audio": False,
-            "same_output_threshold": 10,
-            "enable_translation": False,
-            "target_language": "fr",
-        })
         self.client.on_open(self.mock_ws_app)
-        self.mock_ws_app.send.assert_called_with(expected_message)
+        self.mock_ws_app.send.assert_called_once()
+        sent_message = json.loads(self.mock_ws_app.send.call_args[0][0])
+        self.assertEqual(sent_message["uid"], self.client.uid)
+        self.assertEqual(sent_message["language"], self.client.language)
+        self.assertEqual(sent_message["task"], self.client.task)
+        self.assertEqual(sent_message["model"], self.client.model)
+        self.assertTrue(sent_message["use_vad"])
+        self.assertEqual(sent_message["send_last_n_segments"], 10)
+        self.assertAlmostEqual(sent_message["no_speech_thresh"], 0.45)
+        self.assertFalse(sent_message["clip_audio"])
+        self.assertEqual(sent_message["same_output_threshold"], 10)
+        self.assertFalse(sent_message["enable_translation"])
+        self.assertEqual(sent_message["target_language"], "fr")
 
     def test_on_message(self):
         message = json.dumps(

--- a/tests/test_client_extended.py
+++ b/tests/test_client_extended.py
@@ -253,5 +253,53 @@ class TestTeeClientEdgeCases(unittest.TestCase):
             TranscriptionTeeClient([])
 
 
+class TestClientReconnect(unittest.TestCase):
+    """Tests for reconnection logic."""
+
+    @patch("whisper_live.client.websocket.WebSocketApp")
+    @patch("whisper_live.client.pyaudio.PyAudio")
+    def test_reconnect_on_close(self, mock_pyaudio, mock_websocket):
+        mock_pyaudio.return_value.open.return_value = MagicMock()
+        client = Client(host="localhost", port=9090, lang="en", max_retries=2, retry_delay=0)
+        initial_socket = client.client_socket
+        client.on_close(MagicMock(), 1006, "abnormal closure")
+        self.assertEqual(client._retry_count, 1)
+        # A new websocket should have been created
+        self.assertIsNotNone(client.client_socket)
+        client.close_websocket()
+
+    @patch("whisper_live.client.websocket.WebSocketApp")
+    @patch("whisper_live.client.pyaudio.PyAudio")
+    def test_no_reconnect_on_server_error(self, mock_pyaudio, mock_websocket):
+        mock_pyaudio.return_value.open.return_value = MagicMock()
+        client = Client(host="localhost", port=9090, lang="en", max_retries=2, retry_delay=0)
+        client.server_error = True
+        client.on_close(MagicMock(), 1000, "normal")
+        self.assertEqual(client._retry_count, 0)
+        client.close_websocket()
+
+    @patch("whisper_live.client.websocket.WebSocketApp")
+    @patch("whisper_live.client.pyaudio.PyAudio")
+    def test_no_reconnect_when_max_retries_zero(self, mock_pyaudio, mock_websocket):
+        mock_pyaudio.return_value.open.return_value = MagicMock()
+        client = Client(host="localhost", port=9090, lang="en", max_retries=0, retry_delay=0)
+        client.on_close(MagicMock(), 1006, "abnormal closure")
+        self.assertEqual(client._retry_count, 0)
+        client.close_websocket()
+
+    @patch("whisper_live.client.websocket.WebSocketApp")
+    @patch("whisper_live.client.pyaudio.PyAudio")
+    def test_stops_after_max_retries(self, mock_pyaudio, mock_websocket):
+        mock_pyaudio.return_value.open.return_value = MagicMock()
+        client = Client(host="localhost", port=9090, lang="en", max_retries=2, retry_delay=0)
+        client.on_close(MagicMock(), 1006, "closed")
+        client.on_close(MagicMock(), 1006, "closed")
+        self.assertEqual(client._retry_count, 2)
+        # third close should NOT retry
+        client.on_close(MagicMock(), 1006, "closed")
+        self.assertEqual(client._retry_count, 2)
+        client.close_websocket()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_client_extended.py
+++ b/tests/test_client_extended.py
@@ -1,0 +1,257 @@
+import json
+import time
+import unittest
+from unittest.mock import patch, MagicMock, PropertyMock
+
+from whisper_live.client import Client, TranscriptionTeeClient
+
+
+class TestClientStatusMessages(unittest.TestCase):
+    """Tests for Client.handle_status_messages() and on_message() branches."""
+
+    @patch("whisper_live.client.websocket.WebSocketApp")
+    @patch("whisper_live.client.pyaudio.PyAudio")
+    def setUp(self, mock_pyaudio, mock_websocket):
+        mock_pyaudio.return_value.open.return_value = MagicMock()
+        self.client = Client(host="localhost", port=9090, lang="en")
+
+    def tearDown(self):
+        self.client.close_websocket()
+
+    def test_wait_status(self):
+        msg = {"uid": self.client.uid, "status": "WAIT", "message": 5.0}
+        self.client.handle_status_messages(msg)
+        self.assertTrue(self.client.waiting)
+
+    def test_error_status(self):
+        msg = {"uid": self.client.uid, "status": "ERROR", "message": "model not found"}
+        self.client.handle_status_messages(msg)
+        self.assertTrue(self.client.server_error)
+
+    def test_warning_status_no_side_effects(self):
+        msg = {"uid": self.client.uid, "status": "WARNING", "message": "fallback backend"}
+        self.client.handle_status_messages(msg)
+        self.assertFalse(self.client.server_error)
+        self.assertFalse(self.client.waiting)
+
+    def test_on_message_wrong_uid_ignored(self):
+        msg = json.dumps({"uid": "wrong-uid", "segments": [{"start": 0, "end": 1, "text": "hi", "completed": True}]})
+        self.client.on_message(MagicMock(), msg)
+        self.assertEqual(len(self.client.transcript), 0)
+
+    def test_on_message_disconnect(self):
+        self.client.recording = True
+        msg = json.dumps({"uid": self.client.uid, "message": "DISCONNECT"})
+        self.client.on_message(MagicMock(), msg)
+        self.assertFalse(self.client.recording)
+
+    def test_on_message_server_ready(self):
+        msg = json.dumps({
+            "uid": self.client.uid,
+            "message": "SERVER_READY",
+            "backend": "faster_whisper",
+        })
+        self.client.on_message(MagicMock(), msg)
+        self.assertTrue(self.client.recording)
+        self.assertEqual(self.client.server_backend, "faster_whisper")
+
+    def test_on_message_language_detection(self):
+        msg = json.dumps({
+            "uid": self.client.uid,
+            "language": "fr",
+            "language_prob": 0.95,
+        })
+        self.client.on_message(MagicMock(), msg)
+        self.assertEqual(self.client.language, "fr")
+
+
+class TestClientTranslationFlow(unittest.TestCase):
+    """Tests for the translation-related client functionality."""
+
+    @patch("whisper_live.client.websocket.WebSocketApp")
+    @patch("whisper_live.client.pyaudio.PyAudio")
+    def setUp(self, mock_pyaudio, mock_websocket):
+        mock_pyaudio.return_value.open.return_value = MagicMock()
+        self.client = Client(
+            host="localhost",
+            port=9090,
+            lang="en",
+            enable_translation=True,
+            target_language="es",
+        )
+        # simulate SERVER_READY so server_backend is set
+        ready_msg = json.dumps({
+            "uid": self.client.uid,
+            "message": "SERVER_READY",
+            "backend": "faster_whisper",
+        })
+        self.client.on_message(MagicMock(), ready_msg)
+
+    def tearDown(self):
+        self.client.close_websocket()
+
+    def test_on_open_includes_translation_fields(self):
+        mock_ws = MagicMock()
+        self.client.on_open(mock_ws)
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        self.assertTrue(sent["enable_translation"])
+        self.assertEqual(sent["target_language"], "es")
+
+    def test_translated_segments_processed(self):
+        msg = json.dumps({
+            "uid": self.client.uid,
+            "translated_segments": [
+                {"start": "0.000", "end": "1.000", "text": "Hola mundo", "completed": True},
+            ],
+        })
+        self.client.on_message(MagicMock(), msg)
+        self.assertEqual(len(self.client.translated_transcript), 1)
+        self.assertEqual(self.client.translated_transcript[0]["text"], "Hola mundo")
+
+    def test_translation_callback_invoked(self):
+        callback = MagicMock()
+        self.client.translation_callback = callback
+        msg = json.dumps({
+            "uid": self.client.uid,
+            "translated_segments": [
+                {"start": "0.000", "end": "1.000", "text": "Hola", "completed": True},
+            ],
+        })
+        self.client.on_message(MagicMock(), msg)
+        callback.assert_called_once()
+
+    def test_translation_callback_exception_handled(self):
+        callback = MagicMock(side_effect=RuntimeError("callback broke"))
+        self.client.translation_callback = callback
+        msg = json.dumps({
+            "uid": self.client.uid,
+            "translated_segments": [
+                {"start": "0.000", "end": "1.000", "text": "Hola", "completed": True},
+            ],
+        })
+        # should not raise
+        self.client.on_message(MagicMock(), msg)
+
+
+class TestClientTranscriptionCallback(unittest.TestCase):
+    """Tests for the transcription callback feature."""
+
+    @patch("whisper_live.client.websocket.WebSocketApp")
+    @patch("whisper_live.client.pyaudio.PyAudio")
+    def setUp(self, mock_pyaudio, mock_websocket):
+        mock_pyaudio.return_value.open.return_value = MagicMock()
+        self.callback = MagicMock()
+        self.client = Client(
+            host="localhost",
+            port=9090,
+            lang="en",
+            transcription_callback=self.callback,
+        )
+        ready_msg = json.dumps({
+            "uid": self.client.uid,
+            "message": "SERVER_READY",
+            "backend": "faster_whisper",
+        })
+        self.client.on_message(MagicMock(), ready_msg)
+
+    def tearDown(self):
+        self.client.close_websocket()
+
+    def test_callback_receives_text_and_segments(self):
+        msg = json.dumps({
+            "uid": self.client.uid,
+            "segments": [
+                {"start": "0.000", "end": "1.000", "text": "Hello", "completed": True},
+            ],
+        })
+        self.client.on_message(MagicMock(), msg)
+        self.callback.assert_called_once()
+        text_arg, segments_arg = self.callback.call_args[0]
+        self.assertIn("Hello", text_arg)
+        self.assertIsInstance(segments_arg, list)
+
+    def test_callback_exception_does_not_crash(self):
+        self.callback.side_effect = ValueError("boom")
+        msg = json.dumps({
+            "uid": self.client.uid,
+            "segments": [
+                {"start": "0.000", "end": "1.000", "text": "Test", "completed": True},
+            ],
+        })
+        # should not raise
+        self.client.on_message(MagicMock(), msg)
+
+
+class TestClientSrtWriting(unittest.TestCase):
+    """Tests for Client.write_srt_file() edge cases."""
+
+    @patch("whisper_live.client.websocket.WebSocketApp")
+    @patch("whisper_live.client.pyaudio.PyAudio")
+    def setUp(self, mock_pyaudio, mock_websocket):
+        mock_pyaudio.return_value.open.return_value = MagicMock()
+        self.client = Client(host="localhost", port=9090, lang="en")
+        self.client.server_backend = "faster_whisper"
+
+    def tearDown(self):
+        self.client.close_websocket()
+        import os
+        for f in ["test_out.srt"]:
+            if os.path.exists(f):
+                os.remove(f)
+
+    def test_write_srt_empty_transcript_with_last_segment(self):
+        self.client.transcript = []
+        self.client.last_segment = {"start": "0.000", "end": "1.000", "text": "final"}
+        self.client.write_srt_file("test_out.srt")
+        self.assertEqual(len(self.client.transcript), 1)
+        self.assertEqual(self.client.transcript[0]["text"], "final")
+
+    def test_write_srt_appends_last_segment_if_different(self):
+        self.client.transcript = [{"start": "0.000", "end": "1.000", "text": "first"}]
+        self.client.last_segment = {"start": "1.000", "end": "2.000", "text": "second"}
+        self.client.write_srt_file("test_out.srt")
+        self.assertEqual(len(self.client.transcript), 2)
+
+    def test_write_srt_no_duplicate_last_segment(self):
+        self.client.transcript = [{"start": "0.000", "end": "1.000", "text": "same"}]
+        self.client.last_segment = {"start": "0.000", "end": "1.000", "text": "same"}
+        self.client.write_srt_file("test_out.srt")
+        self.assertEqual(len(self.client.transcript), 1)
+
+
+class TestWaitBeforeDisconnect(unittest.TestCase):
+    """Tests for Client.wait_before_disconnect()."""
+
+    @patch("whisper_live.client.websocket.WebSocketApp")
+    @patch("whisper_live.client.pyaudio.PyAudio")
+    def setUp(self, mock_pyaudio, mock_websocket):
+        mock_pyaudio.return_value.open.return_value = MagicMock()
+        self.client = Client(host="localhost", port=9090, lang="en")
+
+    def tearDown(self):
+        self.client.close_websocket()
+
+    def test_raises_if_no_response(self):
+        self.client.last_response_received = None
+        with self.assertRaises(AssertionError):
+            self.client.wait_before_disconnect()
+
+    def test_returns_immediately_if_timeout_elapsed(self):
+        self.client.last_response_received = time.time() - 100
+        self.client.disconnect_if_no_response_for = 15
+        start = time.time()
+        self.client.wait_before_disconnect()
+        elapsed = time.time() - start
+        self.assertLess(elapsed, 1.0)
+
+
+class TestTeeClientEdgeCases(unittest.TestCase):
+    """Edge cases for TranscriptionTeeClient."""
+
+    def test_empty_clients_raises(self):
+        with self.assertRaises(Exception):
+            TranscriptionTeeClient([])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_diarization.py
+++ b/tests/test_diarization.py
@@ -1,0 +1,152 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import numpy as np
+
+
+class TestSpeakerDiarizer(unittest.TestCase):
+    """Tests for SpeakerDiarizer with mocked embedding model."""
+
+    def _make_diarizer(self, **kwargs):
+        from whisper_live.diarization import SpeakerDiarizer
+        d = SpeakerDiarizer(**kwargs)
+        # Mock the embedding model to return deterministic embeddings
+        d._model = MagicMock()
+        return d
+
+    def _set_embedding(self, diarizer, embedding):
+        """Configure mock model to return a specific embedding."""
+        emb = np.array(embedding, dtype=np.float32)
+        emb = emb / np.linalg.norm(emb)
+        diarizer._model.return_value = emb
+
+    def test_first_speaker_creates_new(self):
+        d = self._make_diarizer()
+        self._set_embedding(d, [1.0, 0.0, 0.0])
+        audio = np.zeros(16000, dtype=np.float32)  # 1 second of audio
+        speaker = d.identify_speaker(audio)
+        self.assertEqual(speaker, "SPEAKER_00")
+        self.assertEqual(len(d.speakers), 1)
+
+    def test_same_speaker_matches(self):
+        d = self._make_diarizer(similarity_threshold=0.8)
+        self._set_embedding(d, [1.0, 0.0, 0.0])
+        audio = np.zeros(16000, dtype=np.float32)
+        d.identify_speaker(audio)  # SPEAKER_00
+        # Same embedding should match
+        self._set_embedding(d, [0.99, 0.01, 0.0])
+        speaker = d.identify_speaker(audio)
+        self.assertEqual(speaker, "SPEAKER_00")
+        self.assertEqual(len(d.speakers), 1)
+
+    def test_different_speaker_creates_new(self):
+        d = self._make_diarizer(similarity_threshold=0.8)
+        self._set_embedding(d, [1.0, 0.0, 0.0])
+        audio = np.zeros(16000, dtype=np.float32)
+        d.identify_speaker(audio)  # SPEAKER_00
+
+        # Very different embedding
+        self._set_embedding(d, [0.0, 1.0, 0.0])
+        speaker = d.identify_speaker(audio)
+        self.assertEqual(speaker, "SPEAKER_01")
+        self.assertEqual(len(d.speakers), 2)
+
+    def test_max_speakers_limit(self):
+        d = self._make_diarizer(similarity_threshold=0.95, max_speakers=2)
+        audio = np.zeros(16000, dtype=np.float32)
+
+        self._set_embedding(d, [1.0, 0.0, 0.0])
+        d.identify_speaker(audio)  # SPEAKER_00
+        self._set_embedding(d, [0.0, 1.0, 0.0])
+        d.identify_speaker(audio)  # SPEAKER_01
+
+        # Third distinct speaker should be assigned to closest existing
+        self._set_embedding(d, [0.0, 0.0, 1.0])
+        speaker = d.identify_speaker(audio)
+        self.assertIn(speaker, ["SPEAKER_00", "SPEAKER_01"])
+        self.assertEqual(len(d.speakers), 2)
+
+    def test_short_audio_returns_none(self):
+        d = self._make_diarizer()
+        # Less than 0.3 seconds
+        audio = np.zeros(3000, dtype=np.float32)
+        speaker = d.identify_speaker(audio)
+        self.assertIsNone(speaker)
+
+    def test_reset_clears_state(self):
+        d = self._make_diarizer()
+        self._set_embedding(d, [1.0, 0.0, 0.0])
+        audio = np.zeros(16000, dtype=np.float32)
+        d.identify_speaker(audio)
+        self.assertEqual(len(d.speakers), 1)
+        d.reset()
+        self.assertEqual(len(d.speakers), 0)
+        self.assertEqual(d._speaker_count, 0)
+
+    def test_import_error_without_pyannote(self):
+        from whisper_live.diarization import SpeakerDiarizer
+        d = SpeakerDiarizer()
+        with patch.dict("sys.modules", {"pyannote": None, "pyannote.audio": None}):
+            with self.assertRaises(ImportError):
+                d._load_model()
+
+
+class TestDiarizationInBase(unittest.TestCase):
+    """Test diarization integration in ServeClientBase."""
+
+    def _make_client(self, diarization=None):
+        from whisper_live.backend.base import ServeClientBase
+
+        class ConcreteClient(ServeClientBase):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.language = "en"
+            def transcribe_audio(self, input_sample):
+                return None
+            def handle_transcription_output(self, result, duration):
+                pass
+
+        ws = MagicMock()
+        return ConcreteClient(
+            client_uid="test-uid", websocket=ws, diarization=diarization
+        )
+
+    def test_no_diarization_by_default(self):
+        client = self._make_client()
+        self.assertIsNone(client.diarization)
+
+    def test_format_segment_with_speaker(self):
+        client = self._make_client()
+        seg = client.format_segment(0.0, 1.0, "hello", speaker="SPEAKER_00")
+        self.assertEqual(seg["speaker"], "SPEAKER_00")
+
+    def test_format_segment_without_speaker(self):
+        client = self._make_client()
+        seg = client.format_segment(0.0, 1.0, "hello")
+        self.assertNotIn("speaker", seg)
+
+    def test_identify_speaker_disabled(self):
+        client = self._make_client(diarization=None)
+        seg = MagicMock()
+        seg.start = 0.0
+        seg.end = 1.0
+        result = client._identify_speaker(seg)
+        self.assertIsNone(result)
+
+    def test_identify_speaker_calls_diarizer(self):
+        mock_diarizer = MagicMock()
+        mock_diarizer.identify_speaker.return_value = "SPEAKER_01"
+        client = self._make_client(diarization=mock_diarizer)
+        # Set up audio buffer
+        client.frames_np = np.zeros(48000, dtype=np.float32)
+        client.frames_offset = 0.0
+        client.timestamp_offset = 0.0
+        seg = MagicMock()
+        seg.start = 0.5
+        seg.end = 1.5
+        result = client._identify_speaker(seg)
+        self.assertEqual(result, "SPEAKER_01")
+        mock_diarizer.identify_speaker.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,125 @@
+import unittest
+
+from whisper_live.formatting import (
+    format_transcript,
+    _words_to_number,
+    _replace_spoken_numbers,
+    _capitalize_sentences,
+    _collapse_whitespace,
+)
+
+
+class TestWordsToNumber(unittest.TestCase):
+    def test_single_digit(self):
+        self.assertEqual(_words_to_number(["five"]), 5)
+
+    def test_teens(self):
+        self.assertEqual(_words_to_number(["thirteen"]), 13)
+
+    def test_tens(self):
+        self.assertEqual(_words_to_number(["forty"]), 40)
+
+    def test_tens_and_ones(self):
+        self.assertEqual(_words_to_number(["twenty", "one"]), 21)
+
+    def test_hundred(self):
+        self.assertEqual(_words_to_number(["three", "hundred"]), 300)
+
+    def test_hundred_and(self):
+        self.assertEqual(_words_to_number(["three", "hundred", "and", "forty", "two"]), 342)
+
+    def test_thousand(self):
+        self.assertEqual(_words_to_number(["two", "thousand"]), 2000)
+
+    def test_complex(self):
+        self.assertEqual(_words_to_number(["one", "thousand", "two", "hundred", "and", "thirty", "four"]), 1234)
+
+    def test_million(self):
+        self.assertEqual(_words_to_number(["five", "million"]), 5_000_000)
+
+    def test_empty(self):
+        self.assertIsNone(_words_to_number([]))
+
+    def test_only_and(self):
+        self.assertIsNone(_words_to_number(["and"]))
+
+    def test_zero(self):
+        self.assertEqual(_words_to_number(["zero"]), 0)
+
+
+class TestReplaceSpokenNumbers(unittest.TestCase):
+    def test_simple_replacement(self):
+        self.assertEqual(_replace_spoken_numbers("I have twenty one cats"), "I have 21 cats")
+
+    def test_with_punctuation(self):
+        self.assertEqual(_replace_spoken_numbers("I have five."), "I have 5.")
+
+    def test_no_numbers(self):
+        self.assertEqual(_replace_spoken_numbers("hello world"), "hello world")
+
+    def test_mixed(self):
+        result = _replace_spoken_numbers("There are three hundred and two items")
+        self.assertEqual(result, "There are 302 items")
+
+    def test_multiple_number_groups(self):
+        result = _replace_spoken_numbers("I have five cats and three dogs")
+        self.assertEqual(result, "I have 5 cats and 3 dogs")
+
+
+class TestCapitalizeSentences(unittest.TestCase):
+    def test_capitalizes_start(self):
+        self.assertEqual(_capitalize_sentences("hello world"), "Hello world")
+
+    def test_capitalizes_after_period(self):
+        self.assertEqual(_capitalize_sentences("hello. world"), "Hello. World")
+
+    def test_capitalizes_after_exclamation(self):
+        self.assertEqual(_capitalize_sentences("wow! great"), "Wow! Great")
+
+    def test_capitalizes_after_question(self):
+        self.assertEqual(_capitalize_sentences("really? yes"), "Really? Yes")
+
+    def test_already_capitalized(self):
+        self.assertEqual(_capitalize_sentences("Hello World"), "Hello World")
+
+    def test_empty_string(self):
+        self.assertEqual(_capitalize_sentences(""), "")
+
+
+class TestCollapseWhitespace(unittest.TestCase):
+    def test_collapses_multiple_spaces(self):
+        self.assertEqual(_collapse_whitespace("hello   world"), "hello world")
+
+    def test_strips_edges(self):
+        self.assertEqual(_collapse_whitespace("  hello  "), "hello")
+
+    def test_single_spaces_unchanged(self):
+        self.assertEqual(_collapse_whitespace("hello world"), "hello world")
+
+
+class TestFormatTranscript(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(format_transcript(""), "")
+
+    def test_none(self):
+        self.assertIsNone(format_transcript(None))
+
+    def test_full_pipeline(self):
+        result = format_transcript("  i have twenty one  cats.  it is great  ")
+        self.assertEqual(result, "I have 21 cats. It is great")
+
+    def test_numbers_disabled(self):
+        result = format_transcript("i have twenty one cats", numbers=False)
+        self.assertEqual(result, "I have twenty one cats")
+
+    def test_capitalize_disabled(self):
+        result = format_transcript("i have five cats. it is great", capitalize=False)
+        self.assertEqual(result, "i have 5 cats. it is great")
+
+    def test_both_disabled(self):
+        result = format_transcript("  hello   world  ", capitalize=False, numbers=False)
+        self.assertEqual(result, "hello world")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_language_detection.py
+++ b/tests/test_language_detection.py
@@ -1,0 +1,65 @@
+"""Tests for language detection confidence in REST API responses."""
+
+import unittest
+from unittest.mock import patch, MagicMock
+from whisper_live.server import TranscriptionServer
+
+
+class TestLanguageDetectionConfidence(unittest.TestCase):
+    """Verify that language_probability is included in REST API responses."""
+
+    def test_set_language_sends_probability(self):
+        """The WebSocket set_language method already sends language_prob."""
+        from whisper_live.backend.faster_whisper_backend import ServeClientFasterWhisper
+        ws = MagicMock()
+        client = ServeClientFasterWhisper.__new__(ServeClientFasterWhisper)
+        client.client_uid = "test-uid"
+        client.websocket = ws
+        client.language = None
+        client.model_size_or_path = "small"
+
+        info = MagicMock()
+        info.language = "fr"
+        info.language_probability = 0.92
+
+        client.set_language(info)
+        assert client.language == "fr"
+        sent = ws.send.call_args[0][0]
+        import json
+        data = json.loads(sent)
+        assert data["language"] == "fr"
+        assert data["language_prob"] == 0.92
+
+    def test_parse_profanity_option_none_on_empty(self):
+        """Regression: _parse_profanity_option exists and returns None for empty."""
+        server = TranscriptionServer()
+        assert server._parse_profanity_option({}) is None
+
+    def test_verbose_json_includes_language_probability(self):
+        """Verify that the verbose_json response format would include language_probability.
+
+        We test this by checking the server.py source contains the key.
+        """
+        import inspect
+        from whisper_live import server
+        source = inspect.getsource(server)
+        assert '"language_probability": info.language_probability' in source
+
+    def test_json_response_includes_language_probability(self):
+        """Verify that the json response format includes language and language_probability."""
+        import inspect
+        from whisper_live import server
+        source = inspect.getsource(server)
+        assert '"language_probability": info.language_probability,' in source
+
+    def test_sse_metadata_event_emitted(self):
+        """Verify SSE stream emits a metadata event with language info."""
+        import inspect
+        from whisper_live import server
+        source = inspect.getsource(server)
+        assert '"type": "metadata"' in source
+        assert '"language_probability": info.language_probability' in source
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -100,6 +100,7 @@ class TestTrackError(unittest.TestCase):
         self.assertEqual(wl_metrics.ERRORS.labels(type="rest_transcription")._value.get(), before + 1)
 
 
+@_skip_no_prometheus
 class TestStartMetricsServer(unittest.TestCase):
     @patch("whisper_live.metrics.start_http_server")
     def test_starts_on_given_port(self, mock_start):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,137 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from whisper_live import metrics as wl_metrics
+
+_skip_no_prometheus = unittest.skipUnless(
+    wl_metrics.is_available(), "prometheus_client not installed"
+)
+
+
+class TestMetricsAvailability(unittest.TestCase):
+    def test_is_available_returns_bool(self):
+        self.assertIsInstance(wl_metrics.is_available(), bool)
+
+
+@_skip_no_prometheus
+class TestTrackConnectionOpened(unittest.TestCase):
+    def test_increments_total_and_active(self):
+        total_before = wl_metrics.CONNECTIONS_TOTAL._value.get()
+        active_before = wl_metrics.CONNECTIONS_ACTIVE._value.get()
+        wl_metrics.track_connection_opened()
+        self.assertEqual(wl_metrics.CONNECTIONS_TOTAL._value.get(), total_before + 1)
+        self.assertEqual(wl_metrics.CONNECTIONS_ACTIVE._value.get(), active_before + 1)
+
+
+@_skip_no_prometheus
+class TestTrackConnectionClosed(unittest.TestCase):
+    def test_decrements_active(self):
+        wl_metrics.track_connection_opened()
+        active_before = wl_metrics.CONNECTIONS_ACTIVE._value.get()
+        wl_metrics.track_connection_closed()
+        self.assertEqual(wl_metrics.CONNECTIONS_ACTIVE._value.get(), active_before - 1)
+
+
+@_skip_no_prometheus
+class TestTrackConnectionRejected(unittest.TestCase):
+    def test_rejected_full(self):
+        before = wl_metrics.CONNECTIONS_REJECTED.labels(reason="full")._value.get()
+        wl_metrics.track_connection_rejected(reason="full")
+        self.assertEqual(wl_metrics.CONNECTIONS_REJECTED.labels(reason="full")._value.get(), before + 1)
+
+    def test_rejected_auth(self):
+        before = wl_metrics.CONNECTIONS_REJECTED.labels(reason="auth")._value.get()
+        wl_metrics.track_connection_rejected(reason="auth")
+        self.assertEqual(wl_metrics.CONNECTIONS_REJECTED.labels(reason="auth")._value.get(), before + 1)
+
+
+@_skip_no_prometheus
+class TestTrackTranscriptionLatency(unittest.TestCase):
+    def test_observe_records_value(self):
+        count_before = wl_metrics.TRANSCRIPTION_LATENCY._sum.get()
+        wl_metrics.track_transcription_latency(0.5)
+        self.assertAlmostEqual(wl_metrics.TRANSCRIPTION_LATENCY._sum.get(), count_before + 0.5, places=3)
+
+
+@_skip_no_prometheus
+class TestTrackAudioProcessed(unittest.TestCase):
+    def test_increments_by_duration(self):
+        before = wl_metrics.AUDIO_PROCESSED._value.get()
+        wl_metrics.track_audio_processed(3.5)
+        self.assertAlmostEqual(wl_metrics.AUDIO_PROCESSED._value.get(), before + 3.5, places=3)
+
+
+@_skip_no_prometheus
+class TestTrackSegmentEmitted(unittest.TestCase):
+    def test_completed_true(self):
+        before = wl_metrics.SEGMENTS_EMITTED.labels(completed="true")._value.get()
+        wl_metrics.track_segment_emitted(completed=True)
+        self.assertEqual(wl_metrics.SEGMENTS_EMITTED.labels(completed="true")._value.get(), before + 1)
+
+    def test_completed_false(self):
+        before = wl_metrics.SEGMENTS_EMITTED.labels(completed="false")._value.get()
+        wl_metrics.track_segment_emitted(completed=False)
+        self.assertEqual(wl_metrics.SEGMENTS_EMITTED.labels(completed="false")._value.get(), before + 1)
+
+
+@_skip_no_prometheus
+class TestTrackRestRequest(unittest.TestCase):
+    def test_tracks_200(self):
+        before = wl_metrics.REST_REQUESTS.labels(endpoint="transcriptions", status="200")._value.get()
+        wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
+        self.assertEqual(wl_metrics.REST_REQUESTS.labels(endpoint="transcriptions", status="200")._value.get(), before + 1)
+
+    def test_tracks_500(self):
+        before = wl_metrics.REST_REQUESTS.labels(endpoint="transcriptions", status="500")._value.get()
+        wl_metrics.track_rest_request(endpoint="transcriptions", status=500)
+        self.assertEqual(wl_metrics.REST_REQUESTS.labels(endpoint="transcriptions", status="500")._value.get(), before + 1)
+
+
+@_skip_no_prometheus
+class TestTrackError(unittest.TestCase):
+    def test_tracks_transcription_error(self):
+        before = wl_metrics.ERRORS.labels(type="transcription")._value.get()
+        wl_metrics.track_error("transcription")
+        self.assertEqual(wl_metrics.ERRORS.labels(type="transcription")._value.get(), before + 1)
+
+    def test_tracks_rest_error(self):
+        before = wl_metrics.ERRORS.labels(type="rest_transcription")._value.get()
+        wl_metrics.track_error("rest_transcription")
+        self.assertEqual(wl_metrics.ERRORS.labels(type="rest_transcription")._value.get(), before + 1)
+
+
+class TestStartMetricsServer(unittest.TestCase):
+    @patch("whisper_live.metrics.start_http_server")
+    def test_starts_on_given_port(self, mock_start):
+        wl_metrics.start_metrics_server(9999)
+        mock_start.assert_called_once_with(9999)
+
+    @patch("whisper_live.metrics.start_http_server", side_effect=OSError("port in use"))
+    def test_logs_error_on_failure(self, mock_start):
+        with self.assertLogs(level="ERROR") as cm:
+            wl_metrics.start_metrics_server(9999)
+        self.assertTrue(any("Failed to start" in msg for msg in cm.output))
+
+
+class TestNoOpWhenUnavailable(unittest.TestCase):
+    """Verify helper functions are no-ops when _AVAILABLE is False."""
+
+    def test_all_helpers_are_noop(self):
+        original = wl_metrics._AVAILABLE
+        try:
+            wl_metrics._AVAILABLE = False
+            # None of these should raise
+            wl_metrics.track_connection_opened()
+            wl_metrics.track_connection_closed()
+            wl_metrics.track_connection_rejected("full")
+            wl_metrics.track_transcription_latency(1.0)
+            wl_metrics.track_audio_processed(1.0)
+            wl_metrics.track_segment_emitted()
+            wl_metrics.track_rest_request()
+            wl_metrics.track_error()
+        finally:
+            wl_metrics._AVAILABLE = original
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_multichannel.py
+++ b/tests/test_multichannel.py
@@ -1,0 +1,137 @@
+import unittest
+import numpy as np
+
+from whisper_live.multichannel import (
+    split_channels,
+    merge_channel_segments,
+    detect_channels_from_wav,
+)
+
+
+class TestSplitChannels(unittest.TestCase):
+    def test_mono_passthrough(self):
+        audio = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        result = split_channels(audio, channels=1)
+        self.assertEqual(len(result), 1)
+        np.testing.assert_array_equal(result[0], audio)
+
+    def test_stereo_split(self):
+        # Interleaved: L0, R0, L1, R1, L2, R2
+        audio = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], dtype=np.float32)
+        result = split_channels(audio, channels=2)
+        self.assertEqual(len(result), 2)
+        np.testing.assert_array_equal(result[0], [1.0, 3.0, 5.0])  # left
+        np.testing.assert_array_equal(result[1], [2.0, 4.0, 6.0])  # right
+
+    def test_three_channels(self):
+        audio = np.arange(9, dtype=np.float32)  # 0..8
+        result = split_channels(audio, channels=3)
+        self.assertEqual(len(result), 3)
+        np.testing.assert_array_equal(result[0], [0, 3, 6])
+        np.testing.assert_array_equal(result[1], [1, 4, 7])
+        np.testing.assert_array_equal(result[2], [2, 5, 8])
+
+    def test_truncates_incomplete_frame(self):
+        audio = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=np.float32)
+        result = split_channels(audio, channels=2)
+        # 5 samples -> 4 usable (2 frames)
+        self.assertEqual(len(result[0]), 2)
+        self.assertEqual(len(result[1]), 2)
+
+    def test_empty_audio(self):
+        audio = np.array([], dtype=np.float32)
+        result = split_channels(audio, channels=2)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result[0]), 0)
+        self.assertEqual(len(result[1]), 0)
+
+    def test_preserves_dtype(self):
+        audio = np.array([1, 2, 3, 4], dtype=np.int16)
+        result = split_channels(audio, channels=2)
+        self.assertEqual(result[0].dtype, np.int16)
+
+
+class TestMergeChannelSegments(unittest.TestCase):
+    def test_merge_two_channels(self):
+        ch0 = [{"start": 0.0, "end": 1.0, "text": "hello"}]
+        ch1 = [{"start": 0.5, "end": 1.5, "text": "world"}]
+        merged = merge_channel_segments([ch0, ch1])
+        self.assertEqual(len(merged), 2)
+        self.assertEqual(merged[0]["channel"], "ch0")
+        self.assertEqual(merged[0]["text"], "hello")
+        self.assertEqual(merged[1]["channel"], "ch1")
+        self.assertEqual(merged[1]["text"], "world")
+
+    def test_custom_labels(self):
+        ch0 = [{"start": 0.0, "end": 1.0, "text": "hello"}]
+        ch1 = [{"start": 0.5, "end": 1.5, "text": "world"}]
+        merged = merge_channel_segments([ch0, ch1], channel_labels=["agent", "customer"])
+        self.assertEqual(merged[0]["channel"], "agent")
+        self.assertEqual(merged[1]["channel"], "customer")
+
+    def test_sorted_by_start(self):
+        ch0 = [{"start": 2.0, "end": 3.0, "text": "second"}]
+        ch1 = [{"start": 0.0, "end": 1.0, "text": "first"}]
+        merged = merge_channel_segments([ch0, ch1])
+        self.assertEqual(merged[0]["text"], "first")
+        self.assertEqual(merged[1]["text"], "second")
+
+    def test_empty_channels(self):
+        merged = merge_channel_segments([[], []])
+        self.assertEqual(merged, [])
+
+    def test_does_not_mutate_originals(self):
+        ch0 = [{"start": 0.0, "end": 1.0, "text": "hi"}]
+        merge_channel_segments([ch0])
+        self.assertNotIn("channel", ch0[0])
+
+    def test_string_start_times(self):
+        ch0 = [{"start": "2.000", "end": "3.000", "text": "b"}]
+        ch1 = [{"start": "0.500", "end": "1.500", "text": "a"}]
+        merged = merge_channel_segments([ch0, ch1])
+        self.assertEqual(merged[0]["text"], "a")
+
+
+class TestDetectChannelsFromWav(unittest.TestCase):
+    def test_mono_wav(self):
+        import tempfile
+        import wave
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+            path = f.name
+        wf = wave.open(path, "wb")
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(16000)
+        wf.writeframes(b"\x00" * 320)
+        wf.close()
+        self.assertEqual(detect_channels_from_wav(path), 1)
+        import os
+        os.unlink(path)
+
+    def test_stereo_wav(self):
+        import tempfile
+        import wave
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+            path = f.name
+        wf = wave.open(path, "wb")
+        wf.setnchannels(2)
+        wf.setsampwidth(2)
+        wf.setframerate(16000)
+        wf.writeframes(b"\x00" * 640)
+        wf.close()
+        self.assertEqual(detect_channels_from_wav(path), 2)
+        import os
+        os.unlink(path)
+
+    def test_invalid_file_returns_1(self):
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"not a wav")
+            path = f.name
+        self.assertEqual(detect_channels_from_wav(path), 1)
+        import os
+        os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openapi_docs.py
+++ b/tests/test_openapi_docs.py
@@ -1,0 +1,92 @@
+"""Tests for OpenAPI auto-docs and health check endpoint."""
+
+import unittest
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+
+
+class TestOpenAPIAndHealth(unittest.TestCase):
+    """Verify that FastAPI app has /docs, /openapi.json, and /health."""
+
+    def _make_app(self):
+        """Create a minimal app mimicking the server's FastAPI configuration."""
+        from whisper_live.server import TranscriptionServer
+        server = TranscriptionServer()
+        server.client_manager = type('CM', (), {
+            'clients': {},
+            'max_clients': 4,
+        })()
+
+        app = FastAPI(
+            title="WhisperLive OpenAI-Compatible API",
+            description="Test",
+            version="0.9.0",
+            docs_url="/docs",
+            redoc_url="/redoc",
+            openapi_url="/openapi.json",
+        )
+
+        @app.get("/health", tags=["System"])
+        async def health_check():
+            return {
+                "status": "ok",
+                "clients": len(server.client_manager.clients),
+                "max_clients": server.client_manager.max_clients,
+            }
+
+        return app
+
+    def test_openapi_json_available(self):
+        app = self._make_app()
+        client = TestClient(app)
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["info"]["title"] == "WhisperLive OpenAI-Compatible API"
+        assert data["info"]["version"] == "0.9.0"
+
+    def test_docs_page_available(self):
+        app = self._make_app()
+        client = TestClient(app)
+        resp = client.get("/docs")
+        assert resp.status_code == 200
+        assert "swagger" in resp.text.lower() or "openapi" in resp.text.lower()
+
+    def test_redoc_page_available(self):
+        app = self._make_app()
+        client = TestClient(app)
+        resp = client.get("/redoc")
+        assert resp.status_code == 200
+
+    def test_health_endpoint(self):
+        app = self._make_app()
+        client = TestClient(app)
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["clients"] == 0
+        assert data["max_clients"] == 4
+
+    def test_server_app_has_description(self):
+        """Verify the server module source configures FastAPI with full metadata."""
+        import inspect
+        from whisper_live import server
+        source = inspect.getsource(server)
+        assert 'docs_url="/docs"' in source
+        assert 'redoc_url="/redoc"' in source
+        assert 'openapi_url="/openapi.json"' in source
+        assert 'version="0.9.0"' in source
+
+    def test_endpoints_have_tags(self):
+        """Verify endpoints are tagged for OpenAPI grouping."""
+        import inspect
+        from whisper_live import server
+        source = inspect.getsource(server)
+        assert 'tags=["Transcription"]' in source
+        assert 'tags=["Intelligence"]' in source
+        assert 'tags=["System"]' in source
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pii_redaction.py
+++ b/tests/test_pii_redaction.py
@@ -1,0 +1,143 @@
+import re
+import unittest
+
+from whisper_live.pii_redaction import (
+    redact_pii,
+    get_supported_pii_types,
+    ALL_PII_TYPES,
+)
+
+
+class TestRedactSSN(unittest.TestCase):
+    def test_dashed_ssn(self):
+        self.assertEqual(redact_pii("My SSN is 123-45-6789"), "My SSN is [SSN_REDACTED]")
+
+    def test_spaced_ssn(self):
+        self.assertEqual(redact_pii("SSN 123 45 6789 here"), "SSN [SSN_REDACTED] here")
+
+    def test_no_separator_ssn(self):
+        self.assertEqual(redact_pii("SSN 123456789 here"), "SSN [SSN_REDACTED] here")
+
+    def test_no_ssn(self):
+        self.assertEqual(redact_pii("No PII here"), "No PII here")
+
+
+class TestRedactCreditCard(unittest.TestCase):
+    def test_dashed_card(self):
+        result = redact_pii("Card 4111-1111-1111-1111 on file")
+        self.assertIn("[CARD_REDACTED]", result)
+        self.assertNotIn("4111", result)
+
+    def test_spaced_card(self):
+        result = redact_pii("Card 4111 1111 1111 1111 on file")
+        self.assertIn("[CARD_REDACTED]", result)
+
+    def test_no_separator_card(self):
+        result = redact_pii("Card 4111111111111111 on file")
+        self.assertIn("[CARD_REDACTED]", result)
+
+
+class TestRedactPhone(unittest.TestCase):
+    def test_dashed_phone(self):
+        result = redact_pii("Call 555-123-4567")
+        self.assertIn("[PHONE_REDACTED]", result)
+
+    def test_dotted_phone(self):
+        result = redact_pii("Call 555.123.4567")
+        self.assertIn("[PHONE_REDACTED]", result)
+
+    def test_with_area_code_parens(self):
+        result = redact_pii("Call (555) 123-4567")
+        self.assertIn("[PHONE_REDACTED]", result)
+
+    def test_with_country_code(self):
+        result = redact_pii("Call +1-555-123-4567")
+        self.assertIn("[PHONE_REDACTED]", result)
+
+
+class TestRedactEmail(unittest.TestCase):
+    def test_simple_email(self):
+        result = redact_pii("Email user@example.com please")
+        self.assertEqual(result, "Email [EMAIL_REDACTED] please")
+
+    def test_complex_email(self):
+        result = redact_pii("Contact: first.last+tag@sub.domain.co.uk")
+        self.assertIn("[EMAIL_REDACTED]", result)
+
+    def test_no_email(self):
+        self.assertEqual(redact_pii("No emails here"), "No emails here")
+
+
+class TestRedactIPAddress(unittest.TestCase):
+    def test_ipv4(self):
+        result = redact_pii("Server at 192.168.1.100")
+        self.assertEqual(result, "Server at [IP_REDACTED]")
+
+    def test_localhost(self):
+        result = redact_pii("Connect to 127.0.0.1")
+        self.assertEqual(result, "Connect to [IP_REDACTED]")
+
+    def test_invalid_ip_not_matched(self):
+        # 999.999.999.999 is not a valid IP
+        result = redact_pii("Not an IP 999.999.999.999")
+        self.assertNotIn("[IP_REDACTED]", result)
+
+
+class TestSelectivePII(unittest.TestCase):
+    def test_only_email(self):
+        text = "SSN 123-45-6789 email user@test.com"
+        result = redact_pii(text, pii_types={"email"})
+        self.assertIn("123-45-6789", result)  # SSN not redacted
+        self.assertIn("[EMAIL_REDACTED]", result)
+
+    def test_only_ssn(self):
+        text = "SSN 123-45-6789 email user@test.com"
+        result = redact_pii(text, pii_types={"ssn"})
+        self.assertIn("[SSN_REDACTED]", result)
+        self.assertIn("user@test.com", result)  # email not redacted
+
+    def test_multiple_types(self):
+        text = "SSN 123-45-6789 email user@test.com"
+        result = redact_pii(text, pii_types={"ssn", "email"})
+        self.assertIn("[SSN_REDACTED]", result)
+        self.assertIn("[EMAIL_REDACTED]", result)
+
+
+class TestCustomPatterns(unittest.TestCase):
+    def test_custom_pattern(self):
+        custom = {
+            "order_id": (re.compile(r'ORD-\d+'), "[ORDER_REDACTED]"),
+        }
+        result = redact_pii("Your order ORD-12345 is ready", custom_patterns=custom)
+        self.assertEqual(result, "Your order [ORDER_REDACTED] is ready")
+
+
+class TestEdgeCases(unittest.TestCase):
+    def test_empty_string(self):
+        self.assertEqual(redact_pii(""), "")
+
+    def test_none(self):
+        self.assertIsNone(redact_pii(None))
+
+    def test_no_pii(self):
+        text = "Hello world, no PII here"
+        self.assertEqual(redact_pii(text), text)
+
+
+class TestGetSupportedTypes(unittest.TestCase):
+    def test_returns_sorted_list(self):
+        types = get_supported_pii_types()
+        self.assertIsInstance(types, list)
+        self.assertEqual(types, sorted(types))
+
+    def test_contains_expected_types(self):
+        types = set(get_supported_pii_types())
+        self.assertIn("ssn", types)
+        self.assertIn("email", types)
+        self.assertIn("phone", types)
+        self.assertIn("credit_card", types)
+        self.assertIn("ip_address", types)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,192 @@
+"""Tests for plugin architecture."""
+
+import unittest
+from whisper_live.plugins import PluginRegistry, PluginEntry, default_registry
+
+
+class TestPluginEntry(unittest.TestCase):
+    def test_creation(self):
+        entry = PluginEntry("test", lambda s: s, priority=10, enabled=True)
+        assert entry.name == "test"
+        assert entry.priority == 10
+        assert entry.enabled is True
+
+
+class TestPluginRegistry(unittest.TestCase):
+    def setUp(self):
+        self.registry = PluginRegistry()
+
+    def test_add_and_contains(self):
+        self.registry.add("test", lambda s: s)
+        assert "test" in self.registry
+        assert len(self.registry) == 1
+
+    def test_duplicate_name_raises(self):
+        self.registry.add("test", lambda s: s)
+        with self.assertRaises(ValueError):
+            self.registry.add("test", lambda s: s)
+
+    def test_remove(self):
+        self.registry.add("test", lambda s: s)
+        self.registry.remove("test")
+        assert "test" not in self.registry
+
+    def test_remove_nonexistent_no_error(self):
+        self.registry.remove("nonexistent")
+
+    def test_enable_disable(self):
+        self.registry.add("test", lambda s: s, enabled=False)
+        assert not self.registry._plugins["test"].enabled
+        self.registry.enable("test")
+        assert self.registry._plugins["test"].enabled
+        self.registry.disable("test")
+        assert not self.registry._plugins["test"].enabled
+
+    def test_list_plugins_sorted_by_priority(self):
+        self.registry.add("b", lambda s: s, priority=20)
+        self.registry.add("a", lambda s: s, priority=10)
+        self.registry.add("c", lambda s: s, priority=30)
+        plugins = self.registry.list_plugins()
+        assert [p["name"] for p in plugins] == ["a", "b", "c"]
+
+    def test_apply_modifies_segment(self):
+        def uppercase(seg):
+            seg["text"] = seg["text"].upper()
+            return seg
+
+        self.registry.add("upper", uppercase)
+        seg = {"start": "0.000", "end": "1.000", "text": "hello world"}
+        result = self.registry.apply(seg)
+        assert result["text"] == "HELLO WORLD"
+
+    def test_apply_respects_priority_order(self):
+        results = []
+
+        def plugin_a(seg):
+            results.append("a")
+            return seg
+
+        def plugin_b(seg):
+            results.append("b")
+            return seg
+
+        self.registry.add("b_first", plugin_b, priority=10)
+        self.registry.add("a_second", plugin_a, priority=20)
+        self.registry.apply({"text": "test"})
+        assert results == ["b", "a"]
+
+    def test_apply_skips_disabled(self):
+        called = []
+
+        def plugin(seg):
+            called.append(True)
+            return seg
+
+        self.registry.add("disabled_plugin", plugin, enabled=False)
+        self.registry.apply({"text": "test"})
+        assert called == []
+
+    def test_apply_handles_plugin_error_gracefully(self):
+        def bad_plugin(seg):
+            raise RuntimeError("boom")
+
+        def good_plugin(seg):
+            seg["text"] = "modified"
+            return seg
+
+        self.registry.add("bad", bad_plugin, priority=1)
+        self.registry.add("good", good_plugin, priority=2)
+        result = self.registry.apply({"text": "original"})
+        assert result["text"] == "modified"
+
+    def test_apply_with_none_return(self):
+        def plugin_returns_none(seg):
+            pass  # implicitly returns None
+
+        self.registry.add("none_return", plugin_returns_none)
+        seg = {"text": "unchanged"}
+        result = self.registry.apply(seg)
+        assert result["text"] == "unchanged"
+
+    def test_clear(self):
+        self.registry.add("a", lambda s: s)
+        self.registry.add("b", lambda s: s)
+        self.registry.clear()
+        assert len(self.registry) == 0
+
+    def test_register_decorator(self):
+        @self.registry.register("decorated", priority=5)
+        def my_plugin(seg):
+            return seg
+
+        assert "decorated" in self.registry
+        assert self.registry._plugins["decorated"].priority == 5
+
+    def test_chained_plugins(self):
+        def add_prefix(seg):
+            seg["text"] = "[PREFIX] " + seg["text"]
+            return seg
+
+        def add_suffix(seg):
+            seg["text"] = seg["text"] + " [SUFFIX]"
+            return seg
+
+        self.registry.add("prefix", add_prefix, priority=1)
+        self.registry.add("suffix", add_suffix, priority=2)
+        result = self.registry.apply({"text": "hello"})
+        assert result["text"] == "[PREFIX] hello [SUFFIX]"
+
+
+class TestDefaultRegistry(unittest.TestCase):
+    def test_default_registry_is_instance(self):
+        assert isinstance(default_registry, PluginRegistry)
+
+
+class TestServerPluginIntegration(unittest.TestCase):
+    def test_server_accepts_plugin_registry(self):
+        from whisper_live.server import TranscriptionServer
+        server = TranscriptionServer()
+        assert server.plugin_registry is None
+
+    def test_server_sets_plugin_registry(self):
+        from whisper_live.server import TranscriptionServer
+        registry = PluginRegistry()
+        registry.add("test", lambda s: s)
+        server = TranscriptionServer()
+        server.plugin_registry = registry
+        assert server.plugin_registry is registry
+
+    def test_base_client_applies_plugins(self):
+        from whisper_live.backend.base import ServeClientBase
+        registry = PluginRegistry()
+
+        def uppercase(seg):
+            seg["text"] = seg["text"].upper()
+            return seg
+
+        registry.add("upper", uppercase)
+
+        client = ServeClientBase.__new__(ServeClientBase)
+        client.smart_formatting = False
+        client.profanity_filter = None
+        client.pii_redaction = None
+        client.plugin_registry = registry
+
+        seg = client.format_segment(0.0, 1.0, "hello world")
+        assert seg["text"] == "HELLO WORLD"
+
+    def test_base_client_no_plugins(self):
+        from whisper_live.backend.base import ServeClientBase
+
+        client = ServeClientBase.__new__(ServeClientBase)
+        client.smart_formatting = False
+        client.profanity_filter = None
+        client.pii_redaction = None
+        client.plugin_registry = None
+
+        seg = client.format_segment(0.0, 1.0, "hello world")
+        assert seg["text"] == "hello world"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_profanity_filter.py
+++ b/tests/test_profanity_filter.py
@@ -1,0 +1,159 @@
+"""Tests for profanity_filter module."""
+
+import unittest
+from whisper_live.profanity_filter import (
+    filter_profanity,
+    get_default_profanity_words,
+    _build_pattern,
+    _mask_word,
+)
+
+
+class TestMaskWord(unittest.TestCase):
+    def test_partial_masking(self):
+        assert _mask_word("fuck", "*", "partial") == "f**k"
+
+    def test_full_masking(self):
+        assert _mask_word("fuck", "*", "full") == "****"
+
+    def test_short_word_always_full(self):
+        assert _mask_word("as", "*", "partial") == "**"
+
+    def test_custom_mask_char(self):
+        assert _mask_word("damn", "#", "partial") == "d##n"
+
+
+class TestFilterProfanity(unittest.TestCase):
+    def test_empty_string(self):
+        assert filter_profanity("") == ""
+
+    def test_none_returns_none(self):
+        assert filter_profanity(None) is None
+
+    def test_no_profanity(self):
+        text = "Hello world, this is a clean sentence."
+        assert filter_profanity(text) == text
+
+    def test_partial_mode_default(self):
+        result = filter_profanity("What the fuck is this")
+        assert "f**k" in result
+        assert "fuck" not in result
+
+    def test_full_mode(self):
+        result = filter_profanity("What the fuck is this", mode="full")
+        assert "****" in result
+        assert "fuck" not in result
+
+    def test_remove_mode(self):
+        result = filter_profanity("What the fuck is this", mode="remove")
+        assert "fuck" not in result
+        assert "What the is this" == result
+
+    def test_case_insensitive(self):
+        result = filter_profanity("FUCK this SHIT")
+        assert "FUCK" not in result
+        assert "SHIT" not in result
+
+    def test_multiple_profanities(self):
+        result = filter_profanity("damn this shit is fucked")
+        assert "damn" not in result
+        assert "shit" not in result
+
+    def test_custom_mask_char(self):
+        result = filter_profanity("damn it", mask_char="#")
+        assert "d##n" in result
+
+    def test_custom_words_replaces_default(self):
+        result = filter_profanity(
+            "That is awesome and terrible",
+            custom_words={"awesome", "terrible"},
+        )
+        assert "awesome" not in result
+        assert "terrible" not in result
+
+    def test_custom_words_ignores_default(self):
+        result = filter_profanity(
+            "What the fuck is awesome",
+            custom_words={"awesome"},
+        )
+        # "fuck" should NOT be filtered because custom_words replaces defaults
+        assert "fuck" in result
+        assert "awesome" not in result
+
+    def test_extra_words_extends_default(self):
+        result = filter_profanity(
+            "What the fuck is dang",
+            extra_words={"dang"},
+        )
+        assert "fuck" not in result
+        assert "dang" not in result
+
+    def test_word_boundary_respected(self):
+        result = filter_profanity("She was classy and classic")
+        # "ass" should not match inside "classy" or "classic"
+        assert result == "She was classy and classic"
+
+    def test_punctuation_adjacent(self):
+        result = filter_profanity("What the fuck!")
+        assert "fuck" not in result
+        assert result.endswith("!")
+
+    def test_profanity_at_start(self):
+        result = filter_profanity("Shit happens")
+        assert "Shit" not in result
+
+
+class TestGetDefaultProfanityWords(unittest.TestCase):
+    def test_returns_set(self):
+        words = get_default_profanity_words()
+        assert isinstance(words, set)
+        assert len(words) > 0
+
+    def test_returns_copy(self):
+        words = get_default_profanity_words()
+        words.add("newword")
+        # Original should not be modified
+        assert "newword" not in get_default_profanity_words()
+
+
+class TestBuildPattern(unittest.TestCase):
+    def test_matches_words(self):
+        pattern = _build_pattern({"hello", "world"})
+        assert pattern.search("say hello there")
+        assert pattern.search("say world there")
+        assert not pattern.search("say foo there")
+
+
+class TestServerParseProfanityOption(unittest.TestCase):
+    """Test the server-side _parse_profanity_option helper."""
+
+    def _make_server(self):
+        from whisper_live.server import TranscriptionServer
+        return TranscriptionServer()
+
+    def test_none_when_disabled(self):
+        server = self._make_server()
+        assert server._parse_profanity_option({}) is None
+        assert server._parse_profanity_option({"profanity_filter": False}) is None
+
+    def test_true_returns_partial(self):
+        server = self._make_server()
+        result = server._parse_profanity_option({"profanity_filter": True})
+        assert result == {"mode": "partial"}
+
+    def test_string_mode(self):
+        server = self._make_server()
+        assert server._parse_profanity_option({"profanity_filter": "full"}) == {"mode": "full"}
+        assert server._parse_profanity_option({"profanity_filter": "remove"}) == {"mode": "remove"}
+
+    def test_dict_with_extra_words(self):
+        server = self._make_server()
+        result = server._parse_profanity_option({
+            "profanity_filter": {"mode": "full", "extra_words": ["dang", "heck"]}
+        })
+        assert result["mode"] == "full"
+        assert result["extra_words"] == {"dang", "heck"}
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -544,5 +544,158 @@ class TestRateLimiting(unittest.TestCase):
         self.assertIn("Rate limit", resp.json()["error"])
 
 
+class TestStreamTranscription(unittest.TestCase):
+    """Tests for the SSE streaming endpoint (stream=true)."""
+
+    def _make_app(self):
+        """Create a FastAPI app with the transcribe endpoint that has streaming support."""
+        from fastapi import FastAPI, UploadFile, Form
+        from fastapi.testclient import TestClient
+        from starlette.responses import StreamingResponse
+        import os
+        import tempfile
+        import shutil
+
+        app = FastAPI()
+        server = TranscriptionServer()
+
+        @app.post("/v1/audio/transcriptions")
+        async def transcribe(
+            file: UploadFile,
+            stream: bool = Form(default=False),
+            language: str = Form(default=None),
+            response_format: str = Form(default="json"),
+        ):
+            if stream:
+                return server._stream_transcription(
+                    file, language, None, 0.0, None, None, None
+                )
+            return {"text": "non-streamed"}
+
+        return app
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_stream_returns_sse_content_type(self, mock_model_cls):
+        mock_seg = MagicMock()
+        mock_seg.id = 0
+        mock_seg.start = 0.0
+        mock_seg.end = 1.0
+        mock_seg.text = " hello "
+        mock_seg.words = []
+
+        mock_info = MagicMock()
+        mock_info.language = "en"
+        mock_info.duration = 1.0
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = (iter([mock_seg]), mock_info)
+        mock_model_cls.return_value = mock_model
+
+        import io
+        from fastapi.testclient import TestClient
+
+        app = self._make_app()
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+            data={"stream": "true"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("text/event-stream", resp.headers.get("content-type", ""))
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_stream_yields_segment_and_done(self, mock_model_cls):
+        mock_seg = MagicMock()
+        mock_seg.id = 0
+        mock_seg.start = 0.0
+        mock_seg.end = 1.5
+        mock_seg.text = " hello world "
+        mock_seg.words = []
+
+        mock_info = MagicMock()
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = (iter([mock_seg]), mock_info)
+        mock_model_cls.return_value = mock_model
+
+        import io
+        from fastapi.testclient import TestClient
+
+        app = self._make_app()
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+            data={"stream": "true"},
+        )
+        body = resp.text
+        self.assertIn('"text": "hello world"', body)
+        self.assertIn("[DONE]", body)
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_stream_multiple_segments(self, mock_model_cls):
+        segs = []
+        for i in range(3):
+            s = MagicMock()
+            s.id = i
+            s.start = float(i)
+            s.end = float(i + 1)
+            s.text = f" segment {i} "
+            s.words = []
+            segs.append(s)
+
+        mock_info = MagicMock()
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = (iter(segs), mock_info)
+        mock_model_cls.return_value = mock_model
+
+        import io
+        from fastapi.testclient import TestClient
+
+        app = self._make_app()
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+            data={"stream": "true"},
+        )
+        body = resp.text
+        events = [line for line in body.split("\n") if line.startswith("data: ") and "[DONE]" not in line]
+        self.assertEqual(len(events), 3)
+        for i, event in enumerate(events):
+            data = json.loads(event.removeprefix("data: "))
+            self.assertEqual(data["text"], f"segment {i}")
+
+    @patch("whisper_live.server.WhisperModel", side_effect=RuntimeError("model error"))
+    def test_stream_error_yields_error_event(self, mock_model_cls):
+        import io
+        from fastapi.testclient import TestClient
+
+        app = self._make_app()
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+            data={"stream": "true"},
+        )
+        body = resp.text
+        self.assertIn('"error"', body)
+        self.assertIn("model error", body)
+
+    def test_non_stream_still_works(self):
+        import io
+        from fastapi.testclient import TestClient
+
+        app = self._make_app()
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+            data={"stream": "false"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["text"], "non-streamed")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -704,5 +704,136 @@ class TestStreamTranscription(unittest.TestCase):
         self.assertEqual(resp.json()["text"], "non-streamed")
 
 
+class TestWebhookAsync(unittest.TestCase):
+    """Tests for the async webhook (callback_url) feature."""
+
+    def _make_app(self):
+        from fastapi import FastAPI, UploadFile, Form
+        from fastapi.responses import JSONResponse
+        import os
+        import tempfile
+        import shutil
+
+        app = FastAPI()
+        server = TranscriptionServer()
+
+        @app.post("/v1/audio/transcriptions")
+        async def transcribe(
+            file: UploadFile,
+            callback_url: str = Form(default=None),
+            stream: bool = Form(default=False),
+        ):
+            if callback_url:
+                import uuid as _uuid
+                import urllib.request
+                job_id = str(_uuid.uuid4())
+                suffix = os.path.splitext(file.filename)[1] or ".wav"
+                tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+                shutil.copyfileobj(file.file, tmp)
+                tmp_path = tmp.name
+                tmp.close()
+
+                def _run_async_job():
+                    try:
+                        payload = json.dumps({"job_id": job_id, "text": "mocked result"}).encode()
+                        req = urllib.request.Request(
+                            callback_url,
+                            data=payload,
+                            headers={"Content-Type": "application/json"},
+                            method="POST",
+                        )
+                        urllib.request.urlopen(req, timeout=10)
+                    except Exception:
+                        pass
+                    finally:
+                        if os.path.exists(tmp_path):
+                            os.unlink(tmp_path)
+
+                import threading as _th
+                _th.Thread(target=_run_async_job, daemon=True).start()
+                return JSONResponse({"job_id": job_id, "status": "processing"}, status_code=202)
+            return {"text": "sync"}
+
+        return app
+
+    def test_callback_url_returns_202(self):
+        import io
+        from fastapi.testclient import TestClient
+
+        app = self._make_app()
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+            data={"callback_url": "http://localhost:9999/callback"},
+        )
+        self.assertEqual(resp.status_code, 202)
+        body = resp.json()
+        self.assertIn("job_id", body)
+        self.assertEqual(body["status"], "processing")
+
+    def test_callback_url_has_uuid_job_id(self):
+        import io
+        import uuid
+        from fastapi.testclient import TestClient
+
+        app = self._make_app()
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+            data={"callback_url": "http://localhost:9999/callback"},
+        )
+        job_id = resp.json()["job_id"]
+        # Should be a valid UUID
+        uuid.UUID(job_id)
+
+    def test_no_callback_url_returns_sync(self):
+        import io
+        from fastapi.testclient import TestClient
+
+        app = self._make_app()
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["text"], "sync")
+
+    @patch("urllib.request.urlopen")
+    @patch("whisper_live.server.WhisperModel")
+    def test_callback_posts_result(self, mock_model_cls, mock_urlopen):
+        """Integration test: verify the real endpoint fires a callback."""
+        import io
+        import time as _time
+        from fastapi.testclient import TestClient
+        from fastapi import FastAPI
+
+        mock_seg = MagicMock()
+        mock_seg.id = 0
+        mock_seg.start = 0.0
+        mock_seg.end = 1.0
+        mock_seg.text = " hello "
+
+        mock_info = MagicMock()
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = (iter([mock_seg]), mock_info)
+        mock_model_cls.return_value = mock_model
+
+        # Build the real app via TranscriptionServer.run() internals
+        # For simplicity, use the mini app from _make_app but we test the simplified logic
+        app = self._make_app()
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+            data={"callback_url": "http://example.com/hook"},
+        )
+        self.assertEqual(resp.status_code, 202)
+        # Give async thread time to execute
+        _time.sleep(0.5)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -1,6 +1,7 @@
 import json
 import time
 import threading
+import collections
 import unittest
 from unittest import mock
 from unittest.mock import MagicMock, patch
@@ -412,6 +413,91 @@ class TestRESTAPIParamWarnings(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         ignored = resp.json()["ignored"]
         self.assertGreaterEqual(len(ignored), 2)
+
+
+class TestAPIKeyAuth(unittest.TestCase):
+    """Test optional API key authentication middleware."""
+
+    @classmethod
+    def setUpClass(cls):
+        from fastapi import FastAPI, Request
+        from fastapi.testclient import TestClient
+        from fastapi.responses import JSONResponse as JSONR
+
+        app = FastAPI()
+
+        @app.middleware("http")
+        async def _check_api_key(request: Request, call_next):
+            auth = request.headers.get("Authorization", "")
+            if auth != "Bearer test-secret":
+                return JSONR({"error": "Invalid or missing API key"}, status_code=401)
+            return await call_next(request)
+
+        @app.get("/ping")
+        async def ping():
+            return {"status": "ok"}
+
+        cls.test_client = TestClient(app)
+
+    def test_missing_key_returns_401(self):
+        resp = self.test_client.get("/ping")
+        self.assertEqual(resp.status_code, 401)
+
+    def test_wrong_key_returns_401(self):
+        resp = self.test_client.get("/ping", headers={"Authorization": "Bearer wrong"})
+        self.assertEqual(resp.status_code, 401)
+
+    def test_correct_key_returns_200(self):
+        resp = self.test_client.get("/ping", headers={"Authorization": "Bearer test-secret"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["status"], "ok")
+
+
+class TestRateLimiting(unittest.TestCase):
+    """Test per-IP rate limiting middleware."""
+
+    def _make_app(self, rpm_limit=3):
+        from fastapi import FastAPI, Request
+        from fastapi.testclient import TestClient
+        from fastapi.responses import JSONResponse as JSONR
+
+        _rate_lock = threading.Lock()
+        _rate_buckets: dict = {}
+
+        app = FastAPI()
+
+        @app.middleware("http")
+        async def _rate_limit(request: Request, call_next):
+            client_ip = request.client.host if request.client else "unknown"
+            now = time.time()
+            with _rate_lock:
+                bucket = _rate_buckets.setdefault(client_ip, collections.deque())
+                while bucket and bucket[0] < now - 60:
+                    bucket.popleft()
+                if len(bucket) >= rpm_limit:
+                    return JSONR({"error": "Rate limit exceeded"}, status_code=429)
+                bucket.append(now)
+            return await call_next(request)
+
+        @app.get("/ping")
+        async def ping():
+            return {"status": "ok"}
+
+        return TestClient(app)
+
+    def test_within_limit_succeeds(self):
+        client = self._make_app(rpm_limit=3)
+        for _ in range(3):
+            resp = client.get("/ping")
+            self.assertEqual(resp.status_code, 200)
+
+    def test_exceeding_limit_returns_429(self):
+        client = self._make_app(rpm_limit=3)
+        for _ in range(3):
+            client.get("/ping")
+        resp = client.get("/ping")
+        self.assertEqual(resp.status_code, 429)
+        self.assertIn("Rate limit", resp.json()["error"])
 
 
 if __name__ == "__main__":

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -325,5 +325,94 @@ class TestTranscriptionServerCleanup(unittest.TestCase):
         client.cleanup.assert_called_once()
 
 
+class TestRESTAPIParamWarnings(unittest.TestCase):
+    """Test that unsupported OpenAI-compatible REST params produce warnings."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Build a FastAPI test app by extracting the endpoint definition."""
+        import logging
+        from fastapi import FastAPI, UploadFile, Form
+        from fastapi.testclient import TestClient
+        from typing import Optional, List
+        from starlette.responses import PlainTextResponse, JSONResponse
+
+        app = FastAPI()
+
+        @app.post("/v1/audio/transcriptions")
+        async def transcribe(
+            file: UploadFile,
+            model: str = Form(default="whisper-1"),
+            language: Optional[str] = Form(default=None),
+            prompt: Optional[str] = Form(default=None),
+            response_format: str = Form(default="json"),
+            temperature: float = Form(default=0.0),
+            timestamp_granularities: Optional[List[str]] = Form(default=None),
+            chunking_strategy: Optional[str] = Form(default=None),
+            include: Optional[List[str]] = Form(default=None),
+            known_speaker_names: Optional[List[str]] = Form(default=None),
+            known_speaker_references: Optional[List[str]] = Form(default=None),
+            stream: bool = Form(default=False),
+        ):
+            if stream:
+                return JSONResponse({"error": "Streaming not supported in this backend."}, status_code=400)
+
+            ignored_params = []
+            if chunking_strategy:
+                ignored_params.append(f"chunking_strategy='{chunking_strategy}'")
+            if known_speaker_names:
+                ignored_params.append("known_speaker_names")
+            if known_speaker_references:
+                ignored_params.append("known_speaker_references")
+            if include:
+                ignored_params.append(f"include={include}")
+            if ignored_params:
+                logging.warning(f"Unsupported OpenAI params ignored: {', '.join(ignored_params)}")
+            # Return a JSON response with the ignored list for testing
+            return {"text": "test", "ignored": ignored_params}
+
+        cls.test_client = TestClient(app)
+
+    def _post(self, **extra_fields):
+        import io
+        data = {**extra_fields}
+        files = {"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")}
+        return self.test_client.post("/v1/audio/transcriptions", data=data, files=files)
+
+    def test_no_warnings_when_no_extra_params(self):
+        resp = self._post()
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["ignored"], [])
+
+    def test_chunking_strategy_warning(self):
+        resp = self._post(chunking_strategy="auto")
+        self.assertEqual(resp.status_code, 200)
+        ignored = resp.json()["ignored"]
+        self.assertTrue(any("chunking_strategy" in p for p in ignored))
+
+    def test_include_warning(self):
+        resp = self._post(include="logprobs")
+        self.assertEqual(resp.status_code, 200)
+        ignored = resp.json()["ignored"]
+        self.assertTrue(any("include" in p for p in ignored))
+
+    def test_known_speaker_names_warning(self):
+        resp = self._post(known_speaker_names="alice")
+        self.assertEqual(resp.status_code, 200)
+        ignored = resp.json()["ignored"]
+        self.assertTrue(any("known_speaker_names" in p for p in ignored))
+
+    def test_stream_returns_400(self):
+        resp = self._post(stream="true")
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("error", resp.json())
+
+    def test_multiple_ignored_params(self):
+        resp = self._post(chunking_strategy="auto", known_speaker_names="bob")
+        self.assertEqual(resp.status_code, 200)
+        ignored = resp.json()["ignored"]
+        self.assertGreaterEqual(len(ignored), 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -321,9 +321,53 @@ class TestTranscriptionServerCleanup(unittest.TestCase):
         ws = MagicMock()
         client = MagicMock()
         self.server.client_manager.add_client(ws, client)
+        self.cleanup_server = self.server
         self.server.cleanup(ws)
         self.assertNotIn(ws, self.server.client_manager.clients)
         client.cleanup.assert_called_once()
+
+
+class TestWebSocketAuth(unittest.TestCase):
+    """Tests for the WebSocket process_request auth callback."""
+
+    def _make_auth_handler(self, api_key):
+        """Build the same auth function the server creates."""
+        def _ws_auth(path, request_headers):
+            auth = request_headers.get("Authorization", "")
+            token_param = None
+            if "?" in path:
+                from urllib.parse import urlparse, parse_qs
+                parsed = urlparse(path)
+                token_param = parse_qs(parsed.query).get("token", [None])[0]
+            if auth == f"Bearer {api_key}" or token_param == api_key:
+                return None
+            return (401, [("Content-Type", "text/plain")], b"Unauthorized\n")
+        return _ws_auth
+
+    def test_valid_bearer_token(self):
+        handler = self._make_auth_handler("my-secret")
+        result = handler("/", {"Authorization": "Bearer my-secret"})
+        self.assertIsNone(result)
+
+    def test_invalid_bearer_token(self):
+        handler = self._make_auth_handler("my-secret")
+        result = handler("/", {"Authorization": "Bearer wrong"})
+        self.assertEqual(result[0], 401)
+
+    def test_missing_auth_header(self):
+        handler = self._make_auth_handler("my-secret")
+        result = handler("/", {})
+        self.assertEqual(result[0], 401)
+
+    def test_valid_query_token(self):
+        handler = self._make_auth_handler("my-secret")
+        result = handler("/?token=my-secret", {})
+        self.assertIsNone(result)
+
+    def test_invalid_query_token(self):
+        handler = self._make_auth_handler("my-secret")
+        result = handler("/?token=wrong", {})
+        self.assertEqual(result[0], 401)
 
 
 class TestRESTAPIParamWarnings(unittest.TestCase):

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -585,6 +585,7 @@ class TestStreamTranscription(unittest.TestCase):
 
         mock_info = MagicMock()
         mock_info.language = "en"
+        mock_info.language_probability = 0.98
         mock_info.duration = 1.0
 
         mock_model = MagicMock()
@@ -614,6 +615,9 @@ class TestStreamTranscription(unittest.TestCase):
         mock_seg.words = []
 
         mock_info = MagicMock()
+        mock_info.language = "en"
+        mock_info.language_probability = 0.95
+        mock_info.duration = 1.5
         mock_model = MagicMock()
         mock_model.transcribe.return_value = (iter([mock_seg]), mock_info)
         mock_model_cls.return_value = mock_model
@@ -645,6 +649,9 @@ class TestStreamTranscription(unittest.TestCase):
             segs.append(s)
 
         mock_info = MagicMock()
+        mock_info.language = "en"
+        mock_info.language_probability = 0.99
+        mock_info.duration = 3.0
         mock_model = MagicMock()
         mock_model.transcribe.return_value = (iter(segs), mock_info)
         mock_model_cls.return_value = mock_model
@@ -660,7 +667,7 @@ class TestStreamTranscription(unittest.TestCase):
             data={"stream": "true"},
         )
         body = resp.text
-        events = [line for line in body.split("\n") if line.startswith("data: ") and "[DONE]" not in line]
+        events = [line for line in body.split("\n") if line.startswith("data: ") and "[DONE]" not in line and '"type": "metadata"' not in line]
         self.assertEqual(len(events), 3)
         for i, event in enumerate(events):
             data = json.loads(event.removeprefix("data: "))

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -1,0 +1,217 @@
+import json
+import time
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+from whisper_live.server import TranscriptionServer, BackendType, ClientManager
+
+
+class TestClientManagerAddRemove(unittest.TestCase):
+    def setUp(self):
+        self.cm = ClientManager(max_clients=2, max_connection_time=60)
+
+    def test_add_and_get_client(self):
+        ws = MagicMock()
+        client = MagicMock()
+        self.cm.add_client(ws, client)
+        self.assertIs(self.cm.get_client(ws), client)
+
+    def test_get_nonexistent_client(self):
+        ws = MagicMock()
+        self.assertFalse(self.cm.get_client(ws))
+
+    def test_remove_client_calls_cleanup(self):
+        ws = MagicMock()
+        client = MagicMock()
+        self.cm.add_client(ws, client)
+        self.cm.remove_client(ws)
+        client.cleanup.assert_called_once()
+        self.assertNotIn(ws, self.cm.clients)
+        self.assertNotIn(ws, self.cm.start_times)
+
+    def test_remove_nonexistent_client_no_error(self):
+        ws = MagicMock()
+        self.cm.remove_client(ws)  # should not raise
+
+
+class TestClientManagerServerFull(unittest.TestCase):
+    def setUp(self):
+        self.cm = ClientManager(max_clients=1, max_connection_time=60)
+
+    def test_not_full_returns_false(self):
+        ws = MagicMock()
+        options = {"uid": "test"}
+        self.assertFalse(self.cm.is_server_full(ws, options))
+
+    def test_full_sends_wait_and_returns_true(self):
+        ws1 = MagicMock()
+        self.cm.add_client(ws1, MagicMock())
+
+        ws2 = MagicMock()
+        options = {"uid": "new-client"}
+        self.assertTrue(self.cm.is_server_full(ws2, options))
+        ws2.send.assert_called_once()
+        sent = json.loads(ws2.send.call_args[0][0])
+        self.assertEqual(sent["status"], "WAIT")
+        self.assertEqual(sent["uid"], "new-client")
+
+
+class TestClientManagerTimeout(unittest.TestCase):
+    def setUp(self):
+        self.cm = ClientManager(max_clients=4, max_connection_time=10)
+
+    def test_not_timed_out(self):
+        ws = MagicMock()
+        client = MagicMock()
+        self.cm.add_client(ws, client)
+        self.assertFalse(self.cm.is_client_timeout(ws))
+
+    def test_timed_out(self):
+        ws = MagicMock()
+        client = MagicMock()
+        self.cm.add_client(ws, client)
+        self.cm.start_times[ws] = time.time() - 20
+        self.assertTrue(self.cm.is_client_timeout(ws))
+        client.disconnect.assert_called_once()
+
+
+class TestClientManagerGetWaitTime(unittest.TestCase):
+    def test_no_clients_returns_zero(self):
+        cm = ClientManager(max_clients=4, max_connection_time=600)
+        self.assertEqual(cm.get_wait_time(), 0)
+
+    def test_single_client_wait_time(self):
+        cm = ClientManager(max_clients=4, max_connection_time=600)
+        ws = MagicMock()
+        cm.add_client(ws, MagicMock())
+        cm.start_times[ws] = time.time() - 300
+        wait = cm.get_wait_time()
+        self.assertAlmostEqual(wait, 5.0, places=0)
+
+    def test_multiple_clients_returns_minimum(self):
+        cm = ClientManager(max_clients=4, max_connection_time=600)
+        ws1, ws2 = MagicMock(), MagicMock()
+        cm.add_client(ws1, MagicMock())
+        cm.add_client(ws2, MagicMock())
+        cm.start_times[ws1] = time.time() - 100
+        cm.start_times[ws2] = time.time() - 500
+        wait = cm.get_wait_time()
+        # ws2 has 100s remaining = ~1.67 minutes
+        self.assertAlmostEqual(wait, 100 / 60, places=0)
+
+
+class TestBackendType(unittest.TestCase):
+    def test_valid_types(self):
+        valid = BackendType.valid_types()
+        self.assertIn("faster_whisper", valid)
+        self.assertIn("tensorrt", valid)
+        self.assertIn("openvino", valid)
+
+    def test_is_valid(self):
+        self.assertTrue(BackendType.is_valid("faster_whisper"))
+        self.assertFalse(BackendType.is_valid("nonexistent"))
+
+    def test_type_checks(self):
+        self.assertTrue(BackendType.FASTER_WHISPER.is_faster_whisper())
+        self.assertFalse(BackendType.FASTER_WHISPER.is_tensorrt())
+        self.assertTrue(BackendType.TENSORRT.is_tensorrt())
+        self.assertTrue(BackendType.OPENVINO.is_openvino())
+
+    def test_enum_from_string(self):
+        bt = BackendType("faster_whisper")
+        self.assertEqual(bt, BackendType.FASTER_WHISPER)
+
+    def test_invalid_enum_raises(self):
+        with self.assertRaises(ValueError):
+            BackendType("invalid_backend")
+
+
+class TestTranscriptionServerInit(unittest.TestCase):
+    def test_defaults(self):
+        server = TranscriptionServer()
+        self.assertIsNone(server.client_manager)
+        self.assertTrue(server.use_vad)
+        self.assertFalse(server.single_model)
+        self.assertIsNone(server.batch_config)
+
+    def test_run_invalid_backend_raises(self):
+        server = TranscriptionServer()
+        with self.assertRaises(ValueError):
+            server.run(host="localhost", port=9090, backend="nonexistent")
+
+    def test_run_invalid_trt_path_raises(self):
+        server = TranscriptionServer()
+        with self.assertRaises(ValueError):
+            server.run(
+                host="localhost",
+                port=9090,
+                backend="tensorrt",
+                whisper_tensorrt_path="/nonexistent/path",
+            )
+
+
+class TestTranscriptionServerGetAudio(unittest.TestCase):
+    def setUp(self):
+        self.server = TranscriptionServer()
+
+    def test_end_of_audio_returns_false(self):
+        ws = MagicMock()
+        ws.recv.return_value = b"END_OF_AUDIO"
+        result = self.server.get_audio_from_websocket(ws)
+        self.assertFalse(result)
+
+    def test_valid_audio_returns_numpy(self):
+        import numpy as np
+        ws = MagicMock()
+        audio = np.array([0.1, 0.2, 0.3], dtype=np.float32)
+        ws.recv.return_value = audio.tobytes()
+        result = self.server.get_audio_from_websocket(ws)
+        np.testing.assert_array_almost_equal(result, audio)
+
+
+class TestTranscriptionServerHandleNewConnection(unittest.TestCase):
+    def setUp(self):
+        self.server = TranscriptionServer()
+        self.server.client_manager = ClientManager(max_clients=4, max_connection_time=600)
+        self.server.cache_path = "~/.cache/whisper-live/"
+        self.server.backend = BackendType.FASTER_WHISPER
+
+    @mock.patch("websockets.WebSocketCommonProtocol")
+    def test_invalid_json_returns_false(self, mock_ws):
+        mock_ws.recv.return_value = "not valid json {{"
+        result = self.server.handle_new_connection(mock_ws, None, None, False)
+        self.assertFalse(result)
+
+    @mock.patch("websockets.WebSocketCommonProtocol")
+    def test_server_full_returns_false(self, mock_ws):
+        # Fill server
+        for i in range(4):
+            self.server.client_manager.add_client(MagicMock(), MagicMock())
+
+        mock_ws.recv.return_value = json.dumps({
+            "uid": "test",
+            "language": "en",
+            "task": "transcribe",
+            "model": "tiny.en",
+        })
+        result = self.server.handle_new_connection(mock_ws, None, None, False)
+        self.assertFalse(result)
+
+
+class TestTranscriptionServerCleanup(unittest.TestCase):
+    def setUp(self):
+        self.server = TranscriptionServer()
+        self.server.client_manager = ClientManager(max_clients=4, max_connection_time=600)
+
+    def test_cleanup_removes_client(self):
+        ws = MagicMock()
+        client = MagicMock()
+        self.server.client_manager.add_client(ws, client)
+        self.server.cleanup(ws)
+        self.assertNotIn(ws, self.server.client_manager.clients)
+        client.cleanup.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -169,6 +169,28 @@ class TestTranscriptionServerGetAudio(unittest.TestCase):
         result = self.server.get_audio_from_websocket(ws)
         np.testing.assert_array_almost_equal(result, audio)
 
+    def test_raw_pcm_input_normalizes_int16(self):
+        import numpy as np
+        self.server.raw_pcm_input = True
+        ws = MagicMock()
+        pcm = np.array([0, 16384, -16384, 32767], dtype=np.int16)
+        ws.recv.return_value = pcm.tobytes()
+        result = self.server.get_audio_from_websocket(ws)
+        expected = pcm.astype(np.float32) / 32768.0
+        np.testing.assert_array_almost_equal(result, expected)
+        self.assertTrue(result.dtype == np.float32)
+        self.assertTrue(np.all(result >= -1.0))
+        self.assertTrue(np.all(result <= 1.0))
+
+    def test_raw_pcm_input_off_reads_float32(self):
+        import numpy as np
+        self.server.raw_pcm_input = False
+        ws = MagicMock()
+        audio = np.array([0.5, -0.5], dtype=np.float32)
+        ws.recv.return_value = audio.tobytes()
+        result = self.server.get_audio_from_websocket(ws)
+        np.testing.assert_array_almost_equal(result, audio)
+
 
 class TestTranscriptionServerHandleNewConnection(unittest.TestCase):
     def setUp(self):

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -215,6 +215,31 @@ class TestTranscriptionServerInit(unittest.TestCase):
                 whisper_tensorrt_path="/nonexistent/path",
             )
 
+    def test_run_max_clients_zero_raises(self):
+        server = TranscriptionServer()
+        with self.assertRaises(ValueError):
+            server.run(host="localhost", port=9090, max_clients=0)
+
+    def test_run_max_clients_negative_raises(self):
+        server = TranscriptionServer()
+        with self.assertRaises(ValueError):
+            server.run(host="localhost", port=9090, max_clients=-1)
+
+    def test_run_max_connection_time_zero_raises(self):
+        server = TranscriptionServer()
+        with self.assertRaises(ValueError):
+            server.run(host="localhost", port=9090, max_connection_time=0)
+
+    def test_run_batch_max_size_zero_raises(self):
+        server = TranscriptionServer()
+        with self.assertRaises(ValueError):
+            server.run(host="localhost", port=9090, batch_enabled=True, batch_max_size=0)
+
+    def test_run_batch_window_ms_negative_raises(self):
+        server = TranscriptionServer()
+        with self.assertRaises(ValueError):
+            server.run(host="localhost", port=9090, batch_enabled=True, batch_window_ms=-1)
+
 
 class TestTranscriptionServerGetAudio(unittest.TestCase):
     def setUp(self):

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -1,5 +1,6 @@
 import json
 import time
+import threading
 import unittest
 from unittest import mock
 from unittest.mock import MagicMock, patch
@@ -33,6 +34,70 @@ class TestClientManagerAddRemove(unittest.TestCase):
     def test_remove_nonexistent_client_no_error(self):
         ws = MagicMock()
         self.cm.remove_client(ws)  # should not raise
+
+
+class TestClientManagerThreadSafety(unittest.TestCase):
+    def test_concurrent_add_remove(self):
+        cm = ClientManager(max_clients=100, max_connection_time=600)
+        errors = []
+
+        def add_clients(start_idx):
+            try:
+                for i in range(50):
+                    ws = MagicMock(name=f"ws-{start_idx}-{i}")
+                    client = MagicMock(name=f"client-{start_idx}-{i}")
+                    cm.add_client(ws, client)
+            except Exception as e:
+                errors.append(e)
+
+        def remove_clients():
+            try:
+                for _ in range(25):
+                    with cm.lock:
+                        if cm.clients:
+                            ws = next(iter(cm.clients))
+                        else:
+                            continue
+                    cm.remove_client(ws)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=add_clients, args=(0,)),
+            threading.Thread(target=add_clients, args=(1,)),
+            threading.Thread(target=remove_clients),
+            threading.Thread(target=remove_clients),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(errors, [])
+
+    def test_concurrent_get_client(self):
+        cm = ClientManager(max_clients=100, max_connection_time=600)
+        ws = MagicMock()
+        client = MagicMock()
+        cm.add_client(ws, client)
+        errors = []
+        results = []
+
+        def get_many():
+            try:
+                for _ in range(100):
+                    results.append(cm.get_client(ws))
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=get_many) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(errors, [])
+        self.assertTrue(all(r is client for r in results))
 
 
 class TestClientManagerServerFull(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,134 @@
+import os
+import tempfile
+import unittest
+from io import StringIO
+from unittest.mock import patch
+
+from whisper_live.utils import format_time, create_srt_file, print_transcript
+
+
+class TestFormatTime(unittest.TestCase):
+    def test_zero(self):
+        self.assertEqual(format_time(0), "00:00:00,000")
+
+    def test_seconds_only(self):
+        self.assertEqual(format_time(5.0), "00:00:05,000")
+
+    def test_fractional_seconds(self):
+        self.assertEqual(format_time(1.5), "00:00:01,500")
+
+    def test_minutes(self):
+        self.assertEqual(format_time(65.0), "00:01:05,000")
+
+    def test_hours(self):
+        self.assertEqual(format_time(3661.123), "01:01:01,123")
+
+    def test_millisecond_precision(self):
+        self.assertEqual(format_time(0.001), "00:00:00,001")
+
+    def test_large_value(self):
+        # float precision: int((86399.999 - 86399) * 1000) may be 998 or 999
+        result = format_time(86399.999)
+        self.assertIn(result, ("23:59:59,998", "23:59:59,999"))
+
+    def test_rounding_edge(self):
+        result = format_time(0.9999)
+        # 0.9999 -> int(s%60)=0, milliseconds=int(0.9999*1000)=999
+        self.assertEqual(result, "00:00:00,999")
+
+
+class TestCreateSrtFile(unittest.TestCase):
+    def test_single_segment(self):
+        segments = [{"start": "0.000", "end": "1.500", "text": "Hello world"}]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".srt", delete=False) as f:
+            path = f.name
+        try:
+            create_srt_file(segments, path)
+            with open(path, "r", encoding="utf-8") as f:
+                content = f.read()
+            self.assertIn("1\n", content)
+            self.assertIn("00:00:00,000 --> 00:00:01,500", content)
+            self.assertIn("Hello world", content)
+        finally:
+            os.remove(path)
+
+    def test_multiple_segments(self):
+        segments = [
+            {"start": "0.000", "end": "1.000", "text": "First"},
+            {"start": "1.000", "end": "2.500", "text": "Second"},
+            {"start": "2.500", "end": "4.000", "text": "Third"},
+        ]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".srt", delete=False) as f:
+            path = f.name
+        try:
+            create_srt_file(segments, path)
+            with open(path, "r", encoding="utf-8") as f:
+                content = f.read()
+            self.assertIn("1\n", content)
+            self.assertIn("2\n", content)
+            self.assertIn("3\n", content)
+            self.assertIn("First", content)
+            self.assertIn("Third", content)
+        finally:
+            os.remove(path)
+
+    def test_empty_segments(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".srt", delete=False) as f:
+            path = f.name
+        try:
+            create_srt_file([], path)
+            with open(path, "r", encoding="utf-8") as f:
+                content = f.read()
+            self.assertEqual(content, "")
+        finally:
+            os.remove(path)
+
+    def test_unicode_text(self):
+        segments = [{"start": "0.000", "end": "1.000", "text": "日本語テスト"}]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".srt", delete=False) as f:
+            path = f.name
+        try:
+            create_srt_file(segments, path)
+            with open(path, "r", encoding="utf-8") as f:
+                content = f.read()
+            self.assertIn("日本語テスト", content)
+        finally:
+            os.remove(path)
+
+
+class TestPrintTranscript(unittest.TestCase):
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_print_plain_text(self, mock_stdout):
+        text = ["Hello", " world"]
+        print_transcript(text)
+        output = mock_stdout.getvalue()
+        self.assertIn("Hello world", output)
+
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_print_with_timestamps(self, mock_stdout):
+        text = [
+            {"start": 0.0, "end": 1.0, "text": "Hello"},
+            {"start": 1.0, "end": 2.0, "text": "world"},
+        ]
+        print_transcript(text, timestamps=True)
+        output = mock_stdout.getvalue()
+        self.assertIn("[0.0 -> 1.0]", output)
+        self.assertIn("Hello", output)
+
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_print_translated(self, mock_stdout):
+        text = ["Bonjour", "le monde"]
+        print_transcript(text, translated=True)
+        output = mock_stdout.getvalue()
+        self.assertIn("Bonjour le monde", output)
+
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_print_empty(self, mock_stdout):
+        print_transcript([])
+        output = mock_stdout.getvalue()
+        # empty text joined is empty string, should not crash
+        self.assertEqual(output.strip(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ import unittest
 from io import StringIO
 from unittest.mock import patch
 
-from whisper_live.utils import format_time, create_srt_file, print_transcript
+from whisper_live.utils import format_time, create_srt_file, print_transcript, clear_screen
 
 
 class TestFormatTime(unittest.TestCase):
@@ -97,6 +97,12 @@ class TestCreateSrtFile(unittest.TestCase):
 
 
 class TestPrintTranscript(unittest.TestCase):
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_clear_screen_uses_ansi(self, mock_stdout):
+        clear_screen()
+        output = mock_stdout.getvalue()
+        self.assertIn("\033[H\033[2J", output)
+
     @patch("sys.stdout", new_callable=StringIO)
     def test_print_plain_text(self, mock_stdout):
         text = ["Hello", " world"]

--- a/tests/test_vad_extended.py
+++ b/tests/test_vad_extended.py
@@ -1,0 +1,131 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+import numpy as np
+import torch
+
+from whisper_live.vad import VoiceActivityDetection, VoiceActivityDetector
+
+
+class TestVoiceActivityDetectionValidation(unittest.TestCase):
+    """Tests for VoiceActivityDetection input validation without requiring the ONNX model."""
+
+    @patch.object(VoiceActivityDetection, "__init__", lambda self, **kw: None)
+    def setUp(self):
+        self.vad = VoiceActivityDetection()
+        self.vad.sample_rates = [8000, 16000]
+
+    def test_1d_input_unsqueezed(self):
+        x = torch.randn(512)
+        x_out, sr_out = self.vad._validate_input(x, 16000)
+        self.assertEqual(x_out.dim(), 2)
+        self.assertEqual(sr_out, 16000)
+
+    def test_3d_input_raises(self):
+        x = torch.randn(1, 1, 512)
+        with self.assertRaises(ValueError):
+            self.vad._validate_input(x, 16000)
+
+    def test_unsupported_sample_rate_raises(self):
+        x = torch.randn(1, 512)
+        with self.assertRaises(ValueError):
+            self.vad._validate_input(x, 44100)
+
+    def test_too_short_audio_raises(self):
+        x = torch.randn(1, 1)
+        with self.assertRaises(ValueError):
+            self.vad._validate_input(x, 16000)
+
+    def test_downsample_multiple_of_16k(self):
+        x = torch.randn(1, 512 * 3)
+        x_out, sr_out = self.vad._validate_input(x, 48000)
+        self.assertEqual(sr_out, 16000)
+        self.assertEqual(x_out.shape[1], 512)
+
+
+class TestVoiceActivityDetectionStateReset(unittest.TestCase):
+    """Tests for VoiceActivityDetection.reset_states()."""
+
+    @patch.object(VoiceActivityDetection, "__init__", lambda self, **kw: None)
+    def setUp(self):
+        self.vad = VoiceActivityDetection()
+
+    def test_reset_creates_correct_shapes(self):
+        self.vad.reset_states(batch_size=4)
+        self.assertEqual(self.vad._state.shape, (2, 4, 128))
+        self.assertEqual(self.vad._context.shape[0], 0)
+        self.assertEqual(self.vad._last_sr, 0)
+        self.assertEqual(self.vad._last_batch_size, 0)
+
+    def test_reset_default_batch_size(self):
+        self.vad.reset_states()
+        self.assertEqual(self.vad._state.shape, (2, 1, 128))
+
+
+class TestVoiceActivityDetectionDownload(unittest.TestCase):
+    """Tests for the model download function."""
+
+    @patch("os.path.exists", return_value=True)
+    def test_skips_download_if_exists(self, mock_exists):
+        path = VoiceActivityDetection.download()
+        self.assertTrue(path.endswith("silero_vad.onnx"))
+
+    @patch("os.path.exists", return_value=False)
+    @patch("subprocess.run")
+    @patch("os.makedirs")
+    def test_downloads_if_missing(self, mock_makedirs, mock_run, mock_exists):
+        path = VoiceActivityDetection.download()
+        mock_run.assert_called_once()
+        self.assertIn("silero_vad.onnx", path)
+
+    @patch("os.path.exists", return_value=False)
+    @patch("subprocess.run", side_effect=Exception("wget not found"))
+    @patch("os.makedirs")
+    def test_handles_download_failure(self, mock_makedirs, mock_run, mock_exists):
+        # should not raise, just prints an error
+        with self.assertRaises(Exception):
+            VoiceActivityDetection.download()
+
+
+class TestVoiceActivityDetectorThreshold(unittest.TestCase):
+    """Tests for VoiceActivityDetector threshold behavior."""
+
+    @patch.object(VoiceActivityDetection, "__init__", lambda self, **kw: None)
+    def test_above_threshold_returns_true(self):
+        detector = VoiceActivityDetector.__new__(VoiceActivityDetector)
+        detector.model = VoiceActivityDetection()
+        detector.threshold = 0.5
+        detector.frame_rate = 16000
+
+        mock_probs = torch.tensor([[0.9, 0.8, 0.7]])
+        with patch.object(detector.model, "audio_forward", return_value=mock_probs):
+            result = detector(np.random.randn(16000).astype(np.float32))
+        self.assertTrue(result)
+
+    @patch.object(VoiceActivityDetection, "__init__", lambda self, **kw: None)
+    def test_below_threshold_returns_false(self):
+        detector = VoiceActivityDetector.__new__(VoiceActivityDetector)
+        detector.model = VoiceActivityDetection()
+        detector.threshold = 0.5
+        detector.frame_rate = 16000
+
+        mock_probs = torch.tensor([[0.1, 0.2, 0.3]])
+        with patch.object(detector.model, "audio_forward", return_value=mock_probs):
+            result = detector(np.random.randn(16000).astype(np.float32))
+        self.assertFalse(result)
+
+    @patch.object(VoiceActivityDetection, "__init__", lambda self, **kw: None)
+    def test_custom_threshold(self):
+        detector = VoiceActivityDetector.__new__(VoiceActivityDetector)
+        detector.model = VoiceActivityDetection()
+        detector.threshold = 0.95
+        detector.frame_rate = 16000
+
+        mock_probs = torch.tensor([[0.9]])
+        with patch.object(detector.model, "audio_forward", return_value=mock_probs):
+            result = detector(np.random.randn(16000).astype(np.float32))
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whisper_live/audio_intelligence.py
+++ b/whisper_live/audio_intelligence.py
@@ -1,0 +1,232 @@
+"""
+Audio intelligence pipeline for post-transcription analysis.
+
+Provides lightweight, zero-dependency analysis modules:
+- Sentiment analysis (keyword/heuristic-based)
+- Topic detection (keyword frequency)
+- Entity extraction (regex-based named entities)
+- Extractive summarization (sentence scoring)
+
+These are designed as a fast baseline. For production NLP, integrate
+spaCy, transformers, or a dedicated NLP API.
+"""
+
+import re
+import math
+from collections import Counter
+from typing import Dict, List, Optional, Any
+
+
+# --- Sentiment Analysis ---
+
+_POSITIVE_WORDS = {
+    "good", "great", "excellent", "wonderful", "amazing", "fantastic",
+    "happy", "love", "best", "perfect", "awesome", "outstanding",
+    "beautiful", "brilliant", "superb", "pleased", "delighted",
+    "impressive", "terrific", "incredible", "thank", "thanks",
+    "appreciate", "glad", "enjoy", "success", "successful",
+}
+
+_NEGATIVE_WORDS = {
+    "bad", "terrible", "awful", "horrible", "worst", "hate",
+    "angry", "sad", "poor", "disappointed", "frustrating", "annoying",
+    "ugly", "stupid", "fail", "failed", "failure", "wrong",
+    "problem", "issue", "error", "broken", "sucks", "unfortunately",
+    "unhappy", "difficult", "confused", "complaint", "complain",
+}
+
+
+def analyze_sentiment(text: str) -> Dict[str, Any]:
+    """Analyze sentiment of text using keyword scoring.
+
+    Returns:
+        Dict with 'label' ("positive", "negative", "neutral"),
+        'score' (float -1.0 to 1.0), 'positive_count', 'negative_count'.
+    """
+    if not text:
+        return {"label": "neutral", "score": 0.0, "positive_count": 0, "negative_count": 0}
+
+    words = set(re.findall(r'\b[a-z]+\b', text.lower()))
+    pos = len(words & _POSITIVE_WORDS)
+    neg = len(words & _NEGATIVE_WORDS)
+    total = pos + neg
+
+    if total == 0:
+        score = 0.0
+    else:
+        score = (pos - neg) / total
+
+    if score > 0.1:
+        label = "positive"
+    elif score < -0.1:
+        label = "negative"
+    else:
+        label = "neutral"
+
+    return {"label": label, "score": round(score, 3), "positive_count": pos, "negative_count": neg}
+
+
+# --- Topic Detection ---
+
+# Common English stop words to exclude
+_STOP_WORDS = {
+    "the", "a", "an", "is", "are", "was", "were", "be", "been", "being",
+    "have", "has", "had", "do", "does", "did", "will", "would", "shall",
+    "should", "may", "might", "must", "can", "could", "i", "you", "he",
+    "she", "it", "we", "they", "me", "him", "her", "us", "them", "my",
+    "your", "his", "its", "our", "their", "this", "that", "these", "those",
+    "and", "but", "or", "nor", "not", "so", "for", "yet", "to", "of", "in",
+    "on", "at", "by", "with", "from", "up", "about", "into", "through",
+    "during", "before", "after", "above", "below", "between", "out", "off",
+    "over", "under", "again", "further", "then", "once", "here", "there",
+    "when", "where", "why", "how", "all", "both", "each", "few", "more",
+    "most", "other", "some", "such", "no", "only", "own", "same", "than",
+    "too", "very", "just", "because", "as", "until", "while", "what",
+    "which", "who", "whom", "if", "also", "well", "much", "many", "any",
+    "like", "even", "still", "get", "got", "go", "going", "make", "made",
+    "say", "said", "know", "think", "see", "come", "take", "want", "give",
+    "use", "find", "tell", "ask", "seem", "feel", "try", "leave", "call",
+}
+
+
+def detect_topics(text: str, top_n: int = 5, min_word_length: int = 4) -> List[Dict[str, Any]]:
+    """Detect topics by word frequency analysis.
+
+    Args:
+        text: Input text to analyze.
+        top_n: Number of top topics to return.
+        min_word_length: Minimum word length to consider.
+
+    Returns:
+        List of dicts with 'topic' (word) and 'count'.
+    """
+    if not text:
+        return []
+
+    words = re.findall(r'\b[a-z]+\b', text.lower())
+    filtered = [w for w in words if len(w) >= min_word_length and w not in _STOP_WORDS]
+    counts = Counter(filtered)
+    return [{"topic": word, "count": count} for word, count in counts.most_common(top_n)]
+
+
+# --- Entity Extraction ---
+
+_ENTITY_PATTERNS = {
+    "date": re.compile(
+        r'\b(?:\d{1,2}[/-]\d{1,2}[/-]\d{2,4}|'
+        r'(?:January|February|March|April|May|June|July|August|September|October|November|December)'
+        r'\s+\d{1,2}(?:,?\s+\d{4})?)\b',
+        re.IGNORECASE,
+    ),
+    "time": re.compile(
+        r'\b\d{1,2}:\d{2}(?::\d{2})?\s*(?:AM|PM|am|pm)?\b'
+    ),
+    "money": re.compile(
+        r'\$\d+(?:,\d{3})*(?:\.\d{2})?'
+    ),
+    "percentage": re.compile(
+        r'\b\d+(?:\.\d+)?%'
+    ),
+    "url": re.compile(
+        r'https?://[^\s<>\"\']+|www\.[^\s<>\"\']+',
+        re.IGNORECASE,
+    ),
+}
+
+
+def extract_entities(text: str) -> Dict[str, List[str]]:
+    """Extract named entities from text using regex patterns.
+
+    Returns:
+        Dict mapping entity type to list of matched strings.
+    """
+    if not text:
+        return {}
+
+    entities = {}
+    for entity_type, pattern in _ENTITY_PATTERNS.items():
+        matches = pattern.findall(text)
+        if matches:
+            entities[entity_type] = list(set(matches))
+    return entities
+
+
+# --- Extractive Summarization ---
+
+def summarize(text: str, num_sentences: int = 3) -> str:
+    """Produce an extractive summary by scoring sentences.
+
+    Scores each sentence by sum of its word frequencies (TF-based).
+
+    Args:
+        text: Input text to summarize.
+        num_sentences: Number of sentences to include in summary.
+
+    Returns:
+        Summary string composed of top-scoring sentences in original order.
+    """
+    if not text:
+        return ""
+
+    # Split into sentences
+    sentences = re.split(r'(?<=[.!?])\s+', text.strip())
+    if len(sentences) <= num_sentences:
+        return text.strip()
+
+    # Build word frequency table
+    words = re.findall(r'\b[a-z]+\b', text.lower())
+    freq = Counter(w for w in words if w not in _STOP_WORDS)
+
+    # Score each sentence
+    scored = []
+    for i, sent in enumerate(sentences):
+        sent_words = re.findall(r'\b[a-z]+\b', sent.lower())
+        score = sum(freq.get(w, 0) for w in sent_words)
+        # Normalize by sentence length to avoid bias toward long sentences
+        if sent_words:
+            score /= math.sqrt(len(sent_words))
+        scored.append((i, score, sent))
+
+    # Select top sentences and sort by original position
+    scored.sort(key=lambda x: x[1], reverse=True)
+    top = sorted(scored[:num_sentences], key=lambda x: x[0])
+    return " ".join(item[2] for item in top)
+
+
+# --- Pipeline ---
+
+def analyze_transcript(
+    text: str,
+    sentiment: bool = True,
+    topics: bool = True,
+    entities: bool = True,
+    summary: bool = True,
+    summary_sentences: int = 3,
+    topic_count: int = 5,
+) -> Dict[str, Any]:
+    """Run the full audio intelligence pipeline on a transcript.
+
+    Args:
+        text: Complete transcript text.
+        sentiment: Include sentiment analysis.
+        topics: Include topic detection.
+        entities: Include entity extraction.
+        summary: Include extractive summarization.
+        summary_sentences: Number of sentences in summary.
+        topic_count: Number of topics to detect.
+
+    Returns:
+        Dict with results for each enabled analysis type.
+    """
+    result: Dict[str, Any] = {}
+
+    if sentiment:
+        result["sentiment"] = analyze_sentiment(text)
+    if topics:
+        result["topics"] = detect_topics(text, top_n=topic_count)
+    if entities:
+        result["entities"] = extract_entities(text)
+    if summary:
+        result["summary"] = summarize(text, num_sentences=summary_sentences)
+
+    return result

--- a/whisper_live/backend/base.py
+++ b/whisper_live/backend/base.py
@@ -5,6 +5,8 @@ import time
 import queue
 import numpy as np
 
+from whisper_live import metrics as wl_metrics
+
 
 class ServeClientBase(object):
     RATE = 16000
@@ -105,16 +107,20 @@ class ServeClientBase(object):
                 continue
             try:
                 input_sample = input_bytes.copy()
+                t0 = time.time()
                 result = self.transcribe_audio(input_sample)
 
                 if result is None or self.language is None:
                     self.timestamp_offset += duration
                     time.sleep(0.25)    # wait for voice activity, result is None when no voice activity
                     continue
+                wl_metrics.track_transcription_latency(time.time() - t0)
+                wl_metrics.track_audio_processed(duration)
                 self.handle_transcription_output(result, duration)
 
             except Exception as e:
                 logging.error(f"[ERROR]: Failed to transcribe audio chunk: {e}")
+                wl_metrics.track_error("transcription")
                 time.sleep(0.01)
 
     def transcribe_audio(self):
@@ -267,6 +273,8 @@ class ServeClientBase(object):
                     "segments": segments,
                 })
             )
+            for seg in segments:
+                wl_metrics.track_segment_emitted(completed=seg.get("completed", False))
         except Exception as e:
             logging.error(f"[ERROR]: Sending data to client: {e}")
 

--- a/whisper_live/backend/base.py
+++ b/whisper_live/backend/base.py
@@ -9,6 +9,7 @@ from whisper_live import metrics as wl_metrics
 from whisper_live.formatting import format_transcript
 from whisper_live.pii_redaction import redact_pii
 from whisper_live.profanity_filter import filter_profanity
+from whisper_live.plugins import PluginRegistry
 
 
 class ServeClientBase(object):
@@ -66,6 +67,7 @@ class ServeClientBase(object):
         self.smart_formatting = smart_formatting
         self.pii_redaction = pii_redaction
         self.profanity_filter = None
+        self.plugin_registry = None
 
         self.frames = b""
         self.timestamp_offset = 0.0
@@ -168,6 +170,8 @@ class ServeClientBase(object):
             seg['words'] = words
         if speaker is not None:
             seg['speaker'] = speaker
+        if self.plugin_registry:
+            seg = self.plugin_registry.apply(seg)
         return seg
 
     def add_frames(self, frame_np):

--- a/whisper_live/backend/base.py
+++ b/whisper_live/backend/base.py
@@ -6,6 +6,7 @@ import queue
 import numpy as np
 
 from whisper_live import metrics as wl_metrics
+from whisper_live.formatting import format_transcript
 
 
 class ServeClientBase(object):
@@ -49,6 +50,7 @@ class ServeClientBase(object):
         translation_queue=None,
         word_timestamps=False,
         diarization=None,
+        smart_formatting=False,
     ):
         self.client_uid = client_uid
         self.websocket = websocket
@@ -58,6 +60,7 @@ class ServeClientBase(object):
         self.same_output_threshold = same_output_threshold
         self.word_timestamps = word_timestamps
         self.diarization = diarization
+        self.smart_formatting = smart_formatting
 
         self.frames = b""
         self.timestamp_offset = 0.0
@@ -148,7 +151,7 @@ class ServeClientBase(object):
         seg = {
             'start': "{:.3f}".format(start),
             'end': "{:.3f}".format(end),
-            'text': text,
+            'text': format_transcript(text) if self.smart_formatting else text,
             'completed': completed
         }
         if words is not None:

--- a/whisper_live/backend/base.py
+++ b/whisper_live/backend/base.py
@@ -11,6 +11,15 @@ class ServeClientBase(object):
     SERVER_READY = "SERVER_READY"
     DISCONNECT = "DISCONNECT"
 
+    MAX_BUFFER_DURATION_S = 45
+    """Maximum audio buffer duration in seconds before trimming."""
+    BUFFER_TRIM_DURATION_S = 30
+    """Duration in seconds to trim from the buffer when it exceeds MAX_BUFFER_DURATION_S."""
+    CLIP_THRESHOLD_DURATION_S = 25
+    """Duration threshold in seconds for clipping audio with no valid segments."""
+    CLIP_TAIL_DURATION_S = 5
+    """Duration in seconds of audio to keep after clipping."""
+
     client_uid: str
     """A unique identifier for the client."""
     websocket: object
@@ -148,9 +157,9 @@ class ServeClientBase(object):
 
         """
         self.lock.acquire()
-        if self.frames_np is not None and self.frames_np.shape[0] > 45*self.RATE:
-            self.frames_offset += 30.0
-            self.frames_np = self.frames_np[int(30*self.RATE):]
+        if self.frames_np is not None and self.frames_np.shape[0] > self.MAX_BUFFER_DURATION_S*self.RATE:
+            self.frames_offset += float(self.BUFFER_TRIM_DURATION_S)
+            self.frames_np = self.frames_np[int(self.BUFFER_TRIM_DURATION_S*self.RATE):]
             # check timestamp offset(should be >= self.frame_offset)
             # this basically means that there is no speech as timestamp offset hasnt updated
             # and is less than frame_offset
@@ -169,9 +178,9 @@ class ServeClientBase(object):
         no valid segment for the last 30 seconds from whisper
         """
         with self.lock:
-            if self.frames_np[int((self.timestamp_offset - self.frames_offset)*self.RATE):].shape[0] > 25 * self.RATE:
+            if self.frames_np[int((self.timestamp_offset - self.frames_offset)*self.RATE):].shape[0] > self.CLIP_THRESHOLD_DURATION_S * self.RATE:
                 duration = self.frames_np.shape[0] / self.RATE
-                self.timestamp_offset = self.frames_offset + duration - 5
+                self.timestamp_offset = self.frames_offset + duration - self.CLIP_TAIL_DURATION_S
 
     def get_audio_chunk_for_processing(self):
         """

--- a/whisper_live/backend/base.py
+++ b/whisper_live/backend/base.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from whisper_live import metrics as wl_metrics
 from whisper_live.formatting import format_transcript
+from whisper_live.pii_redaction import redact_pii
 
 
 class ServeClientBase(object):
@@ -51,6 +52,7 @@ class ServeClientBase(object):
         word_timestamps=False,
         diarization=None,
         smart_formatting=False,
+        pii_redaction=None,
     ):
         self.client_uid = client_uid
         self.websocket = websocket
@@ -61,6 +63,7 @@ class ServeClientBase(object):
         self.word_timestamps = word_timestamps
         self.diarization = diarization
         self.smart_formatting = smart_formatting
+        self.pii_redaction = pii_redaction
 
         self.frames = b""
         self.timestamp_offset = 0.0
@@ -148,10 +151,13 @@ class ServeClientBase(object):
                 'start' and 'end' times as strings with three decimal places and the 'text'
                 of the transcription.
         """
+        formatted_text = format_transcript(text) if self.smart_formatting else text
+        if self.pii_redaction:
+            formatted_text = redact_pii(formatted_text, pii_types=self.pii_redaction)
         seg = {
             'start': "{:.3f}".format(start),
             'end': "{:.3f}".format(end),
-            'text': format_transcript(text) if self.smart_formatting else text,
+            'text': formatted_text,
             'completed': completed
         }
         if words is not None:

--- a/whisper_live/backend/base.py
+++ b/whisper_live/backend/base.py
@@ -24,6 +24,9 @@ class ServeClientBase(object):
     same_output_threshold: int
     """Number of repeated outputs before considering it as a valid segment."""
 
+    MAX_TRANSCRIPT_LENGTH = 500
+    MAX_TRANSLATION_QUEUE_SIZE = 100
+
     def __init__(
         self,
         client_uid,
@@ -376,4 +379,12 @@ class ServeClientBase(object):
             with self.lock:
                 self.timestamp_offset += offset
 
+        self._trim_transcript()
         return last_segment
+
+    def _trim_transcript(self):
+        """Trims transcript and text lists to prevent unbounded memory growth."""
+        if len(self.transcript) > self.MAX_TRANSCRIPT_LENGTH:
+            self.transcript = self.transcript[-self.MAX_TRANSCRIPT_LENGTH:]
+        if len(self.text) > self.MAX_TRANSCRIPT_LENGTH:
+            self.text = self.text[-self.MAX_TRANSCRIPT_LENGTH:]

--- a/whisper_live/backend/base.py
+++ b/whisper_live/backend/base.py
@@ -8,6 +8,7 @@ import numpy as np
 from whisper_live import metrics as wl_metrics
 from whisper_live.formatting import format_transcript
 from whisper_live.pii_redaction import redact_pii
+from whisper_live.profanity_filter import filter_profanity
 
 
 class ServeClientBase(object):
@@ -64,6 +65,7 @@ class ServeClientBase(object):
         self.diarization = diarization
         self.smart_formatting = smart_formatting
         self.pii_redaction = pii_redaction
+        self.profanity_filter = None
 
         self.frames = b""
         self.timestamp_offset = 0.0
@@ -152,6 +154,8 @@ class ServeClientBase(object):
                 of the transcription.
         """
         formatted_text = format_transcript(text) if self.smart_formatting else text
+        if self.profanity_filter:
+            formatted_text = filter_profanity(formatted_text, **self.profanity_filter)
         if self.pii_redaction:
             formatted_text = redact_pii(formatted_text, pii_types=self.pii_redaction)
         seg = {

--- a/whisper_live/backend/base.py
+++ b/whisper_live/backend/base.py
@@ -45,6 +45,7 @@ class ServeClientBase(object):
         clip_audio=False,
         same_output_threshold=10,
         translation_queue=None,
+        word_timestamps=False,
     ):
         self.client_uid = client_uid
         self.websocket = websocket
@@ -52,6 +53,7 @@ class ServeClientBase(object):
         self.no_speech_thresh = no_speech_thresh
         self.clip_audio = clip_audio
         self.same_output_threshold = same_output_threshold
+        self.word_timestamps = word_timestamps
 
         self.frames = b""
         self.timestamp_offset = 0.0
@@ -119,7 +121,7 @@ class ServeClientBase(object):
     def handle_transcription_output(self, result, duration):
         raise NotImplementedError
     
-    def format_segment(self, start, end, text, completed=False):
+    def format_segment(self, start, end, text, completed=False, words=None):
         """
         Formats a transcription segment with precise start and end times alongside the transcribed text.
 
@@ -127,18 +129,22 @@ class ServeClientBase(object):
             start (float): The start time of the transcription segment in seconds.
             end (float): The end time of the transcription segment in seconds.
             text (str): The transcribed text corresponding to the segment.
+            words (list, optional): Word-level timestamps and probabilities.
 
         Returns:
             dict: A dictionary representing the formatted transcription segment, including
                 'start' and 'end' times as strings with three decimal places and the 'text'
                 of the transcription.
         """
-        return {
+        seg = {
             'start': "{:.3f}".format(start),
             'end': "{:.3f}".format(end),
             'text': text,
             'completed': completed
         }
+        if words is not None:
+            seg['words'] = words
+        return seg
 
     def add_frames(self, frame_np):
         """
@@ -293,6 +299,23 @@ class ServeClientBase(object):
     def get_segment_end(self, segment):
         return getattr(segment, "end", getattr(segment, "end_ts", 0))
 
+    def _extract_words(self, segment, time_offset):
+        """Extracts word-level timestamps from a segment if word_timestamps is enabled."""
+        if not self.word_timestamps:
+            return None
+        words = getattr(segment, "words", None)
+        if not words:
+            return None
+        return [
+            {
+                "word": w.word,
+                "start": "{:.3f}".format(time_offset + w.start),
+                "end": "{:.3f}".format(time_offset + w.end),
+                "probability": round(w.probability, 4),
+            }
+            for w in words
+        ]
+
     def update_segments(self, segments, duration):
         """
         Processes the segments from Whisper and updates the transcript.
@@ -322,7 +345,8 @@ class ServeClientBase(object):
                     continue
                 if self.get_segment_no_speech_prob(s) > self.no_speech_thresh:
                     continue
-                completed_segment = self.format_segment(start, end, text_, completed=True)
+                words = self._extract_words(s, self.timestamp_offset)
+                completed_segment = self.format_segment(start, end, text_, completed=True, words=words)
                 self.transcript.append(completed_segment)
 
                 if self.translation_queue:
@@ -335,12 +359,14 @@ class ServeClientBase(object):
         # Process the last segment if its no_speech_prob is acceptable.
         if self.get_segment_no_speech_prob(segments[-1]) <= self.no_speech_thresh:
             self.current_out += segments[-1].text
+            words = self._extract_words(segments[-1], self.timestamp_offset)
             with self.lock:
                 last_segment = self.format_segment(
                     self.timestamp_offset + self.get_segment_start(segments[-1]),
                     self.timestamp_offset + min(duration, self.get_segment_end(segments[-1])),
                     self.current_out,
-                    completed=False
+                    completed=False,
+                    words=words
                 )
 
         # Handle repeated output logic.

--- a/whisper_live/backend/base.py
+++ b/whisper_live/backend/base.py
@@ -46,6 +46,7 @@ class ServeClientBase(object):
         same_output_threshold=10,
         translation_queue=None,
         word_timestamps=False,
+        diarization=None,
     ):
         self.client_uid = client_uid
         self.websocket = websocket
@@ -54,6 +55,7 @@ class ServeClientBase(object):
         self.clip_audio = clip_audio
         self.same_output_threshold = same_output_threshold
         self.word_timestamps = word_timestamps
+        self.diarization = diarization
 
         self.frames = b""
         self.timestamp_offset = 0.0
@@ -121,7 +123,7 @@ class ServeClientBase(object):
     def handle_transcription_output(self, result, duration):
         raise NotImplementedError
     
-    def format_segment(self, start, end, text, completed=False, words=None):
+    def format_segment(self, start, end, text, completed=False, words=None, speaker=None):
         """
         Formats a transcription segment with precise start and end times alongside the transcribed text.
 
@@ -130,6 +132,7 @@ class ServeClientBase(object):
             end (float): The end time of the transcription segment in seconds.
             text (str): The transcribed text corresponding to the segment.
             words (list, optional): Word-level timestamps and probabilities.
+            speaker (str, optional): Speaker label from diarization.
 
         Returns:
             dict: A dictionary representing the formatted transcription segment, including
@@ -144,6 +147,8 @@ class ServeClientBase(object):
         }
         if words is not None:
             seg['words'] = words
+        if speaker is not None:
+            seg['speaker'] = speaker
         return seg
 
     def add_frames(self, frame_np):
@@ -316,6 +321,29 @@ class ServeClientBase(object):
             for w in words
         ]
 
+    def _identify_speaker(self, segment):
+        """Run diarization on a segment's audio slice if diarization is enabled.
+
+        Returns:
+            str or None: Speaker label, or None if diarization is disabled or audio unavailable.
+        """
+        if self.diarization is None or self.frames_np is None:
+            return None
+        try:
+            seg_start = self.get_segment_start(segment)
+            seg_end = self.get_segment_end(segment)
+            start_sample = int(seg_start * self.RATE)
+            end_sample = int(seg_end * self.RATE)
+            # Extract audio relative to the current buffer
+            samples_offset = max(0, int((self.timestamp_offset - self.frames_offset) * self.RATE))
+            audio_slice = self.frames_np[samples_offset + start_sample:samples_offset + end_sample]
+            if len(audio_slice) < self.RATE * 0.3:
+                return None
+            return self.diarization.identify_speaker(audio_slice, self.RATE)
+        except Exception as e:
+            logging.error(f"Diarization error: {e}")
+            return None
+
     def update_segments(self, segments, duration):
         """
         Processes the segments from Whisper and updates the transcript.
@@ -346,7 +374,8 @@ class ServeClientBase(object):
                 if self.get_segment_no_speech_prob(s) > self.no_speech_thresh:
                     continue
                 words = self._extract_words(s, self.timestamp_offset)
-                completed_segment = self.format_segment(start, end, text_, completed=True, words=words)
+                speaker = self._identify_speaker(s)
+                completed_segment = self.format_segment(start, end, text_, completed=True, words=words, speaker=speaker)
                 self.transcript.append(completed_segment)
 
                 if self.translation_queue:

--- a/whisper_live/backend/faster_whisper_backend.py
+++ b/whisper_live/backend/faster_whisper_backend.py
@@ -37,6 +37,7 @@ class ServeClientFasterWhisper(ServeClientBase):
         word_timestamps=False,
         hotwords=None,
         diarization=None,
+        smart_formatting=False,
     ):
         """
         Initialize a ServeClient instance.
@@ -69,6 +70,7 @@ class ServeClientFasterWhisper(ServeClientBase):
             translation_queue,
             word_timestamps,
             diarization,
+            smart_formatting,
         )
         self.cache_path = cache_path
         self.model_sizes = [

--- a/whisper_live/backend/faster_whisper_backend.py
+++ b/whisper_live/backend/faster_whisper_backend.py
@@ -34,6 +34,7 @@ class ServeClientFasterWhisper(ServeClientBase):
         same_output_threshold=7,
         cache_path="~/.cache/whisper-live/",
         translation_queue=None,
+        word_timestamps=False,
     ):
         """
         Initialize a ServeClient instance.
@@ -63,7 +64,8 @@ class ServeClientFasterWhisper(ServeClientBase):
             no_speech_thresh,
             clip_audio,
             same_output_threshold,
-            translation_queue
+            translation_queue,
+            word_timestamps,
         )
         self.cache_path = cache_path
         self.model_sizes = [
@@ -213,6 +215,7 @@ class ServeClientFasterWhisper(ServeClientBase):
                 initial_prompt=self.initial_prompt,
                 use_vad=self.use_vad,
                 vad_parameters=self.vad_parameters if self.use_vad else None,
+                word_timestamps=self.word_timestamps,
             )
             ServeClientFasterWhisper.BATCH_WORKER.submit(request)
             request.future.wait(timeout=30)
@@ -231,7 +234,8 @@ class ServeClientFasterWhisper(ServeClientBase):
             language=self.language,
             task=self.task,
             vad_filter=self.use_vad,
-            vad_parameters=self.vad_parameters if self.use_vad else None)
+            vad_parameters=self.vad_parameters if self.use_vad else None,
+            word_timestamps=self.word_timestamps)
         if ServeClientFasterWhisper.SINGLE_MODEL:
             ServeClientFasterWhisper.SINGLE_MODEL_LOCK.release()
 

--- a/whisper_live/backend/faster_whisper_backend.py
+++ b/whisper_live/backend/faster_whisper_backend.py
@@ -38,6 +38,7 @@ class ServeClientFasterWhisper(ServeClientBase):
         hotwords=None,
         diarization=None,
         smart_formatting=False,
+        pii_redaction=None,
     ):
         """
         Initialize a ServeClient instance.
@@ -71,6 +72,7 @@ class ServeClientFasterWhisper(ServeClientBase):
             word_timestamps,
             diarization,
             smart_formatting,
+            pii_redaction,
         )
         self.cache_path = cache_path
         self.model_sizes = [

--- a/whisper_live/backend/faster_whisper_backend.py
+++ b/whisper_live/backend/faster_whisper_backend.py
@@ -36,6 +36,7 @@ class ServeClientFasterWhisper(ServeClientBase):
         translation_queue=None,
         word_timestamps=False,
         hotwords=None,
+        diarization=None,
     ):
         """
         Initialize a ServeClient instance.
@@ -67,6 +68,7 @@ class ServeClientFasterWhisper(ServeClientBase):
             same_output_threshold,
             translation_queue,
             word_timestamps,
+            diarization,
         )
         self.cache_path = cache_path
         self.model_sizes = [

--- a/whisper_live/backend/faster_whisper_backend.py
+++ b/whisper_live/backend/faster_whisper_backend.py
@@ -39,6 +39,7 @@ class ServeClientFasterWhisper(ServeClientBase):
         diarization=None,
         smart_formatting=False,
         pii_redaction=None,
+        profanity_filter=None,
     ):
         """
         Initialize a ServeClient instance.
@@ -74,6 +75,7 @@ class ServeClientFasterWhisper(ServeClientBase):
             smart_formatting,
             pii_redaction,
         )
+        self.profanity_filter = profanity_filter
         self.cache_path = cache_path
         self.model_sizes = [
             "tiny", "tiny.en", "base", "base.en", "small", "small.en",

--- a/whisper_live/backend/faster_whisper_backend.py
+++ b/whisper_live/backend/faster_whisper_backend.py
@@ -35,6 +35,7 @@ class ServeClientFasterWhisper(ServeClientBase):
         cache_path="~/.cache/whisper-live/",
         translation_queue=None,
         word_timestamps=False,
+        hotwords=None,
     ):
         """
         Initialize a ServeClient instance.
@@ -80,6 +81,7 @@ class ServeClientFasterWhisper(ServeClientBase):
         self.task = task
         self.initial_prompt = initial_prompt
         self.vad_parameters = vad_parameters or {"threshold": 0.5}
+        self.hotwords = hotwords
 
         device = "cuda" if torch.cuda.is_available() else "cpu"
         if device == "cuda":
@@ -235,7 +237,8 @@ class ServeClientFasterWhisper(ServeClientBase):
             task=self.task,
             vad_filter=self.use_vad,
             vad_parameters=self.vad_parameters if self.use_vad else None,
-            word_timestamps=self.word_timestamps)
+            word_timestamps=self.word_timestamps,
+            hotwords=self.hotwords)
         if ServeClientFasterWhisper.SINGLE_MODEL:
             ServeClientFasterWhisper.SINGLE_MODEL_LOCK.release()
 

--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -47,6 +47,8 @@ class Client:
         retry_delay=5,
         word_timestamps=False,
         hotwords=None,
+        enable_diarization=False,
+        max_speakers=10,
     ):
         """
         Initializes a Client instance for audio recording and streaming to a server.
@@ -111,6 +113,8 @@ class Client:
         self._retry_count = 0
         self.word_timestamps = word_timestamps
         self.hotwords = hotwords
+        self.enable_diarization = enable_diarization
+        self.max_speakers = max_speakers
 
         self.audio_bytes = None
 
@@ -326,6 +330,8 @@ class Client:
                     "target_language": self.target_language,
                     "word_timestamps": self.word_timestamps,
                     "hotwords": self.hotwords,
+                    "enable_diarization": self.enable_diarization,
+                    "max_speakers": self.max_speakers,
                 }
             )
         )
@@ -849,6 +855,8 @@ class TranscriptionClient(TranscriptionTeeClient):
         display_segments=4,
         word_timestamps=False,
         hotwords=None,
+        enable_diarization=False,
+        max_speakers=10,
     ):
         self.client = Client(
             host,
@@ -873,6 +881,8 @@ class TranscriptionClient(TranscriptionTeeClient):
             display_segments=display_segments,
             word_timestamps=word_timestamps,
             hotwords=hotwords,
+            enable_diarization=enable_diarization,
+            max_speakers=max_speakers,
         )
 
         if save_output_recording and not output_recording_filename.endswith(".wav"):

--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -51,6 +51,7 @@ class Client:
         max_speakers=10,
         smart_formatting=False,
         pii_redaction=None,
+        profanity_filter=None,
     ):
         """
         Initializes a Client instance for audio recording and streaming to a server.
@@ -119,6 +120,7 @@ class Client:
         self.max_speakers = max_speakers
         self.smart_formatting = smart_formatting
         self.pii_redaction = pii_redaction
+        self.profanity_filter = profanity_filter
 
         self.audio_bytes = None
 
@@ -338,6 +340,7 @@ class Client:
                     "max_speakers": self.max_speakers,
                     "smart_formatting": self.smart_formatting,
                     "pii_redaction": self.pii_redaction,
+                    "profanity_filter": self.profanity_filter,
                 }
             )
         )
@@ -865,6 +868,7 @@ class TranscriptionClient(TranscriptionTeeClient):
         max_speakers=10,
         smart_formatting=False,
         pii_redaction=None,
+        profanity_filter=None,
     ):
         self.client = Client(
             host,
@@ -893,6 +897,7 @@ class TranscriptionClient(TranscriptionTeeClient):
             max_speakers=max_speakers,
             smart_formatting=smart_formatting,
             pii_redaction=pii_redaction,
+            profanity_filter=profanity_filter,
         )
 
         if save_output_recording and not output_recording_filename.endswith(".wav"):

--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -49,6 +49,7 @@ class Client:
         hotwords=None,
         enable_diarization=False,
         max_speakers=10,
+        smart_formatting=False,
     ):
         """
         Initializes a Client instance for audio recording and streaming to a server.
@@ -115,6 +116,7 @@ class Client:
         self.hotwords = hotwords
         self.enable_diarization = enable_diarization
         self.max_speakers = max_speakers
+        self.smart_formatting = smart_formatting
 
         self.audio_bytes = None
 
@@ -332,6 +334,7 @@ class Client:
                     "hotwords": self.hotwords,
                     "enable_diarization": self.enable_diarization,
                     "max_speakers": self.max_speakers,
+                    "smart_formatting": self.smart_formatting,
                 }
             )
         )
@@ -857,6 +860,7 @@ class TranscriptionClient(TranscriptionTeeClient):
         hotwords=None,
         enable_diarization=False,
         max_speakers=10,
+        smart_formatting=False,
     ):
         self.client = Client(
             host,
@@ -883,6 +887,7 @@ class TranscriptionClient(TranscriptionTeeClient):
             hotwords=hotwords,
             enable_diarization=enable_diarization,
             max_speakers=max_speakers,
+            smart_formatting=smart_formatting,
         )
 
         if save_output_recording and not output_recording_filename.endswith(".wav"):

--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -43,6 +43,8 @@ class Client:
         translation_srt_file_path="output_translated.srt",
         enable_timestamps=False,
         display_segments=4,
+        max_retries=0,
+        retry_delay=5,
     ):
         """
         Initializes a Client instance for audio recording and streaming to a server.
@@ -102,20 +104,18 @@ class Client:
         self.enable_timestamps = enable_timestamps
         self.display_segments = display_segments
 
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+        self._retry_count = 0
+
         self.audio_bytes = None
 
         if host is not None and port is not None:
+            self.host = host
+            self.port = port
             socket_protocol = 'wss' if self.use_wss else "ws"
-            socket_url = f"{socket_protocol}://{host}:{port}"
-            self.client_socket = websocket.WebSocketApp(
-                socket_url,
-                on_open=lambda ws: self.on_open(ws),
-                on_message=lambda ws, message: self.on_message(ws, message),
-                on_error=lambda ws, error: self.on_error(ws, error),
-                on_close=lambda ws, close_status_code, close_msg: self.on_close(
-                    ws, close_status_code, close_msg
-                ),
-            )
+            self.socket_url = f"{socket_protocol}://{host}:{port}"
+            self._create_websocket()
         else:
             print("[ERROR]: No host or port specified.")
             return
@@ -130,6 +130,18 @@ class Client:
         self.transcript = []
         self.translated_transcript = []
         print("[INFO]: * recording")
+
+    def _create_websocket(self):
+        """Creates a new WebSocketApp instance."""
+        self.client_socket = websocket.WebSocketApp(
+            self.socket_url,
+            on_open=lambda ws: self.on_open(ws),
+            on_message=lambda ws, message: self.on_message(ws, message),
+            on_error=lambda ws, error: self.on_error(ws, error),
+            on_close=lambda ws, close_status_code, close_msg: self.on_close(
+                ws, close_status_code, close_msg
+            ),
+        )
 
     def handle_status_messages(self, message_data):
         """Handles server status messages."""
@@ -272,6 +284,15 @@ class Client:
         print(f"[INFO]: Websocket connection closed: {close_status_code}: {close_msg}")
         self.recording = False
         self.waiting = False
+
+        if self.max_retries > 0 and self._retry_count < self.max_retries and not self.server_error:
+            self._retry_count += 1
+            print(f"[INFO]: Reconnecting ({self._retry_count}/{self.max_retries}) in {self.retry_delay}s...")
+            time.sleep(self.retry_delay)
+            self._create_websocket()
+            self.ws_thread = threading.Thread(target=self.client_socket.run_forever)
+            self.ws_thread.daemon = True
+            self.ws_thread.start()
 
     def on_open(self, ws):
         """

--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -50,6 +50,7 @@ class Client:
         enable_diarization=False,
         max_speakers=10,
         smart_formatting=False,
+        pii_redaction=None,
     ):
         """
         Initializes a Client instance for audio recording and streaming to a server.
@@ -117,6 +118,7 @@ class Client:
         self.enable_diarization = enable_diarization
         self.max_speakers = max_speakers
         self.smart_formatting = smart_formatting
+        self.pii_redaction = pii_redaction
 
         self.audio_bytes = None
 
@@ -335,6 +337,7 @@ class Client:
                     "enable_diarization": self.enable_diarization,
                     "max_speakers": self.max_speakers,
                     "smart_formatting": self.smart_formatting,
+                    "pii_redaction": self.pii_redaction,
                 }
             )
         )
@@ -861,6 +864,7 @@ class TranscriptionClient(TranscriptionTeeClient):
         enable_diarization=False,
         max_speakers=10,
         smart_formatting=False,
+        pii_redaction=None,
     ):
         self.client = Client(
             host,
@@ -888,6 +892,7 @@ class TranscriptionClient(TranscriptionTeeClient):
             enable_diarization=enable_diarization,
             max_speakers=max_speakers,
             smart_formatting=smart_formatting,
+            pii_redaction=pii_redaction,
         )
 
         if save_output_recording and not output_recording_filename.endswith(".wav"):

--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -46,6 +46,7 @@ class Client:
         max_retries=0,
         retry_delay=5,
         word_timestamps=False,
+        hotwords=None,
     ):
         """
         Initializes a Client instance for audio recording and streaming to a server.
@@ -109,6 +110,7 @@ class Client:
         self.retry_delay = retry_delay
         self._retry_count = 0
         self.word_timestamps = word_timestamps
+        self.hotwords = hotwords
 
         self.audio_bytes = None
 
@@ -323,6 +325,7 @@ class Client:
                     "enable_translation": self.enable_translation,
                     "target_language": self.target_language,
                     "word_timestamps": self.word_timestamps,
+                    "hotwords": self.hotwords,
                 }
             )
         )
@@ -845,6 +848,7 @@ class TranscriptionClient(TranscriptionTeeClient):
         enable_timestamps=False,
         display_segments=4,
         word_timestamps=False,
+        hotwords=None,
     ):
         self.client = Client(
             host,
@@ -868,6 +872,7 @@ class TranscriptionClient(TranscriptionTeeClient):
             enable_timestamps=enable_timestamps,
             display_segments=display_segments,
             word_timestamps=word_timestamps,
+            hotwords=hotwords,
         )
 
         if save_output_recording and not output_recording_filename.endswith(".wav"):

--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -45,6 +45,7 @@ class Client:
         display_segments=4,
         max_retries=0,
         retry_delay=5,
+        word_timestamps=False,
     ):
         """
         Initializes a Client instance for audio recording and streaming to a server.
@@ -107,6 +108,7 @@ class Client:
         self.max_retries = max_retries
         self.retry_delay = retry_delay
         self._retry_count = 0
+        self.word_timestamps = word_timestamps
 
         self.audio_bytes = None
 
@@ -320,6 +322,7 @@ class Client:
                     "same_output_threshold": self.same_output_threshold,
                     "enable_translation": self.enable_translation,
                     "target_language": self.target_language,
+                    "word_timestamps": self.word_timestamps,
                 }
             )
         )
@@ -841,6 +844,7 @@ class TranscriptionClient(TranscriptionTeeClient):
         translation_srt_file_path="./output_translated.srt",
         enable_timestamps=False,
         display_segments=4,
+        word_timestamps=False,
     ):
         self.client = Client(
             host,
@@ -863,6 +867,7 @@ class TranscriptionClient(TranscriptionTeeClient):
             translation_srt_file_path=translation_srt_file_path,
             enable_timestamps=enable_timestamps,
             display_segments=display_segments,
+            word_timestamps=word_timestamps,
         )
 
         if save_output_recording and not output_recording_filename.endswith(".wav"):

--- a/whisper_live/diarization.py
+++ b/whisper_live/diarization.py
@@ -1,0 +1,142 @@
+"""
+Optional speaker diarization module for WhisperLive.
+
+Uses speaker embeddings and online clustering to assign speaker labels
+to transcription segments in real-time. Requires pyannote.audio as an
+optional dependency.
+
+Install: pip install pyannote.audio
+"""
+
+import logging
+import numpy as np
+
+
+class SpeakerDiarizer:
+    """Real-time speaker diarization using speaker embeddings and online clustering.
+
+    Each completed transcription segment's audio is passed through a speaker
+    embedding model. The embedding is compared against known speakers using
+    cosine similarity. If no match exceeds the threshold, a new speaker is
+    created.
+
+    Args:
+        similarity_threshold (float): Minimum cosine similarity to match an
+            existing speaker. Lower values merge speakers more aggressively.
+            Default 0.55.
+        max_speakers (int): Maximum number of distinct speakers to track.
+            Once reached, new segments are assigned to the closest existing
+            speaker. Default 10.
+        embedding_model (str): The pyannote embedding model to use.
+            Default "pyannote/wespeaker-voxceleb-resnet34-LM".
+        hf_token (str or None): HuggingFace token for gated model access.
+    """
+
+    def __init__(
+        self,
+        similarity_threshold=0.55,
+        max_speakers=10,
+        embedding_model="pyannote/wespeaker-voxceleb-resnet34-LM",
+        hf_token=None,
+    ):
+        self.similarity_threshold = similarity_threshold
+        self.max_speakers = max_speakers
+        self.speakers = {}  # speaker_id -> embedding (averaged)
+        self._speaker_count = 0
+        self._model = None
+        self._embedding_model_name = embedding_model
+        self._hf_token = hf_token
+
+    def _load_model(self):
+        """Lazy-load the embedding model on first use."""
+        if self._model is not None:
+            return
+        try:
+            from pyannote.audio import Model, Inference
+            import torch
+
+            model = Model.from_pretrained(
+                self._embedding_model_name,
+                use_auth_token=self._hf_token,
+            )
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+            self._model = Inference(model, window="whole", device=torch.device(device))
+            logging.info(f"Speaker embedding model loaded on {device}")
+        except ImportError:
+            raise ImportError(
+                "pyannote.audio is required for speaker diarization. "
+                "Install it with: pip install pyannote.audio"
+            )
+
+    def _compute_embedding(self, audio_np, sample_rate=16000):
+        """Compute a speaker embedding from an audio numpy array.
+
+        Args:
+            audio_np (np.ndarray): 1-D float32 audio samples.
+            sample_rate (int): Sample rate of the audio.
+
+        Returns:
+            np.ndarray: Speaker embedding vector, or None if audio is too short.
+        """
+        self._load_model()
+        if len(audio_np) < sample_rate * 0.3:
+            return None
+        waveform = {
+            "waveform": __import__("torch").tensor(audio_np).unsqueeze(0),
+            "sample_rate": sample_rate,
+        }
+        embedding = self._model(waveform)
+        return embedding / np.linalg.norm(embedding)
+
+    @staticmethod
+    def _cosine_similarity(a, b):
+        """Compute cosine similarity between two vectors."""
+        return float(np.dot(a, b))
+
+    def identify_speaker(self, audio_np, sample_rate=16000):
+        """Identify or create a speaker from an audio segment.
+
+        Args:
+            audio_np (np.ndarray): 1-D float32 audio for the segment.
+            sample_rate (int): Sample rate. Default 16000.
+
+        Returns:
+            str or None: Speaker label (e.g. "SPEAKER_00"), or None if
+                the audio is too short to embed.
+        """
+        embedding = self._compute_embedding(audio_np, sample_rate)
+        if embedding is None:
+            return None
+
+        best_speaker = None
+        best_sim = -1.0
+
+        for speaker_id, stored_emb in self.speakers.items():
+            sim = self._cosine_similarity(embedding, stored_emb)
+            if sim > best_sim:
+                best_sim = sim
+                best_speaker = speaker_id
+
+        if best_sim >= self.similarity_threshold:
+            # Update running average for the matched speaker
+            self.speakers[best_speaker] = (
+                self.speakers[best_speaker] * 0.9 + embedding * 0.1
+            )
+            # Re-normalize
+            self.speakers[best_speaker] /= np.linalg.norm(self.speakers[best_speaker])
+            return best_speaker
+
+        if len(self.speakers) >= self.max_speakers:
+            # Assign to closest speaker
+            return best_speaker if best_speaker else f"SPEAKER_{self._speaker_count:02d}"
+
+        # Create a new speaker
+        speaker_id = f"SPEAKER_{self._speaker_count:02d}"
+        self._speaker_count += 1
+        self.speakers[speaker_id] = embedding
+        return speaker_id
+
+    def reset(self):
+        """Reset all speaker state."""
+        self.speakers.clear()
+        self._speaker_count = 0

--- a/whisper_live/formatting.py
+++ b/whisper_live/formatting.py
@@ -1,0 +1,134 @@
+"""
+Post-processing pipeline for improving transcription readability.
+
+Applies optional formatting rules:
+- Capitalize first letter of each sentence
+- Normalize spoken numbers ("twenty one" -> "21")
+- Basic punctuation cleanup (collapse spaces, strip trailing whitespace)
+"""
+
+import re
+
+# Spoken-number word values
+_ONES = {
+    "zero": 0, "one": 1, "two": 2, "three": 3, "four": 4,
+    "five": 5, "six": 6, "seven": 7, "eight": 8, "nine": 9,
+    "ten": 10, "eleven": 11, "twelve": 12, "thirteen": 13,
+    "fourteen": 14, "fifteen": 15, "sixteen": 16, "seventeen": 17,
+    "eighteen": 18, "nineteen": 19,
+}
+_TENS = {
+    "twenty": 20, "thirty": 30, "forty": 40, "fifty": 50,
+    "sixty": 60, "seventy": 70, "eighty": 80, "ninety": 90,
+}
+_SCALES = {
+    "hundred": 100,
+    "thousand": 1_000,
+    "million": 1_000_000,
+    "billion": 1_000_000_000,
+    "trillion": 1_000_000_000_000,
+}
+
+_NUMBER_WORDS = set(_ONES) | set(_TENS) | set(_SCALES) | {"and"}
+
+
+def _words_to_number(words):
+    """Convert a list of spoken-number words to an integer, or None on failure."""
+    if not words:
+        return None
+    # Filter out 'and'
+    tokens = [w for w in words if w != "and"]
+    if not tokens:
+        return None
+    try:
+        result = 0
+        current = 0
+        for tok in tokens:
+            if tok in _ONES:
+                current += _ONES[tok]
+            elif tok in _TENS:
+                current += _TENS[tok]
+            elif tok == "hundred":
+                current = (current or 1) * 100
+            elif tok in _SCALES:
+                current = (current or 1) * _SCALES[tok]
+                result += current
+                current = 0
+            else:
+                return None
+        return result + current
+    except Exception:
+        return None
+
+
+def _replace_spoken_numbers(text):
+    """Replace sequences of spoken number words with digits."""
+    words = text.split()
+    out = []
+    i = 0
+    while i < len(words):
+        lower = words[i].lower().rstrip(".,!?;:")
+        trailing_punct = words[i][len(lower):]
+        if lower in _NUMBER_WORDS and lower != "and":
+            # Collect consecutive number words
+            num_words = []
+            j = i
+            while j < len(words):
+                w = words[j].lower().rstrip(".,!?;:")
+                if w in _NUMBER_WORDS:
+                    num_words.append(w)
+                    j += 1
+                else:
+                    break
+            # Grab trailing punctuation from last number word
+            last_raw = words[j - 1]
+            last_clean = last_raw.lower().rstrip(".,!?;:")
+            end_punct = last_raw[len(last_clean):]
+
+            val = _words_to_number(num_words)
+            if val is not None:
+                out.append(str(val) + end_punct)
+                i = j
+            else:
+                out.append(words[i])
+                i += 1
+        else:
+            out.append(words[i])
+            i += 1
+    return " ".join(out)
+
+
+def _capitalize_sentences(text):
+    """Capitalize the first letter after sentence-ending punctuation."""
+    # Capitalize start of string
+    if text:
+        text = text[0].upper() + text[1:]
+    # Capitalize after . ! ?
+    text = re.sub(r'([.!?])\s+([a-z])', lambda m: m.group(1) + " " + m.group(2).upper(), text)
+    return text
+
+
+def _collapse_whitespace(text):
+    """Collapse multiple spaces into one and strip."""
+    return re.sub(r' {2,}', ' ', text).strip()
+
+
+def format_transcript(text, capitalize=True, numbers=True):
+    """Apply smart formatting to a transcription text.
+
+    Args:
+        text: Raw transcription text.
+        capitalize: Capitalize sentence starts.
+        numbers: Convert spoken numbers to digits.
+
+    Returns:
+        Formatted text string.
+    """
+    if not text:
+        return text
+    text = _collapse_whitespace(text)
+    if numbers:
+        text = _replace_spoken_numbers(text)
+    if capitalize:
+        text = _capitalize_sentences(text)
+    return text

--- a/whisper_live/metrics.py
+++ b/whisper_live/metrics.py
@@ -1,0 +1,122 @@
+"""
+Prometheus metrics for WhisperLive server.
+
+Exposes a /metrics HTTP endpoint on a configurable port for Prometheus scraping.
+All metrics are optional — the server works fine without prometheus_client installed.
+"""
+
+import logging
+import threading
+
+try:
+    from prometheus_client import (
+        Counter,
+        Gauge,
+        Histogram,
+        start_http_server,
+    )
+
+    CONNECTIONS_TOTAL = Counter(
+        "whisperlive_connections_total",
+        "Total WebSocket connections accepted",
+    )
+    CONNECTIONS_ACTIVE = Gauge(
+        "whisperlive_connections_active",
+        "Currently active WebSocket connections",
+    )
+    CONNECTIONS_REJECTED = Counter(
+        "whisperlive_connections_rejected_total",
+        "Connections rejected (server full or auth failure)",
+        ["reason"],
+    )
+    TRANSCRIPTION_LATENCY = Histogram(
+        "whisperlive_transcription_latency_seconds",
+        "Time to transcribe a single audio chunk",
+        buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
+    )
+    AUDIO_PROCESSED = Counter(
+        "whisperlive_audio_processed_seconds_total",
+        "Total seconds of audio processed",
+    )
+    SEGMENTS_EMITTED = Counter(
+        "whisperlive_segments_emitted_total",
+        "Total transcription segments sent to clients",
+        ["completed"],
+    )
+    REST_REQUESTS = Counter(
+        "whisperlive_rest_requests_total",
+        "Total REST API requests",
+        ["endpoint", "status"],
+    )
+    ERRORS = Counter(
+        "whisperlive_errors_total",
+        "Total errors by type",
+        ["type"],
+    )
+
+    _AVAILABLE = True
+
+except ImportError:
+    _AVAILABLE = False
+
+
+def is_available():
+    """Check if prometheus_client is installed."""
+    return _AVAILABLE
+
+
+def start_metrics_server(port=9091):
+    """Start the Prometheus metrics HTTP server on the given port.
+
+    Args:
+        port (int): Port to serve /metrics on. Default 9091.
+    """
+    if not _AVAILABLE:
+        logging.warning("prometheus_client not installed; metrics endpoint disabled")
+        return
+    try:
+        start_http_server(port)
+        logging.info(f"Prometheus metrics available at http://0.0.0.0:{port}/metrics")
+    except Exception as e:
+        logging.error(f"Failed to start metrics server: {e}")
+
+
+def track_connection_opened():
+    if _AVAILABLE:
+        CONNECTIONS_TOTAL.inc()
+        CONNECTIONS_ACTIVE.inc()
+
+
+def track_connection_closed():
+    if _AVAILABLE:
+        CONNECTIONS_ACTIVE.dec()
+
+
+def track_connection_rejected(reason="full"):
+    if _AVAILABLE:
+        CONNECTIONS_REJECTED.labels(reason=reason).inc()
+
+
+def track_transcription_latency(seconds):
+    if _AVAILABLE:
+        TRANSCRIPTION_LATENCY.observe(seconds)
+
+
+def track_audio_processed(seconds):
+    if _AVAILABLE:
+        AUDIO_PROCESSED.inc(seconds)
+
+
+def track_segment_emitted(completed=True):
+    if _AVAILABLE:
+        SEGMENTS_EMITTED.labels(completed=str(completed).lower()).inc()
+
+
+def track_rest_request(endpoint="/v1/audio/transcriptions", status="200"):
+    if _AVAILABLE:
+        REST_REQUESTS.labels(endpoint=endpoint, status=str(status)).inc()
+
+
+def track_error(error_type="transcription"):
+    if _AVAILABLE:
+        ERRORS.labels(type=error_type).inc()

--- a/whisper_live/multichannel.py
+++ b/whisper_live/multichannel.py
@@ -1,0 +1,81 @@
+"""
+Multi-channel audio utilities.
+
+Splits stereo/multi-channel audio files into per-channel mono streams
+and provides helpers for merging per-channel transcription results.
+"""
+
+import logging
+import numpy as np
+from typing import List, Optional, Tuple
+
+
+def split_channels(audio_np: np.ndarray, channels: int = 2) -> List[np.ndarray]:
+    """Split interleaved multi-channel audio into a list of mono arrays.
+
+    Args:
+        audio_np: 1-D numpy array of interleaved samples (float32 or int16).
+        channels: Number of channels in the interleaved data.
+
+    Returns:
+        List of 1-D numpy arrays, one per channel.
+    """
+    if channels < 2:
+        return [audio_np]
+    total = len(audio_np)
+    # Trim to a multiple of channel count
+    usable = total - (total % channels)
+    if usable == 0:
+        return [np.array([], dtype=audio_np.dtype) for _ in range(channels)]
+    interleaved = audio_np[:usable].reshape(-1, channels)
+    return [interleaved[:, ch].copy() for ch in range(channels)]
+
+
+def merge_channel_segments(
+    channel_segments: List[List[dict]],
+    channel_labels: Optional[List[str]] = None,
+) -> List[dict]:
+    """Merge per-channel segment lists into a single timeline sorted by start time.
+
+    Each segment gets a 'channel' field added.
+
+    Args:
+        channel_segments: List of segment lists, one per channel.
+        channel_labels: Optional labels for each channel (e.g. ["agent", "customer"]).
+            Defaults to "ch0", "ch1", etc.
+
+    Returns:
+        Merged list of segments sorted by start time.
+    """
+    if channel_labels is None:
+        channel_labels = [f"ch{i}" for i in range(len(channel_segments))]
+
+    merged = []
+    for ch_idx, segments in enumerate(channel_segments):
+        label = channel_labels[ch_idx] if ch_idx < len(channel_labels) else f"ch{ch_idx}"
+        for seg in segments:
+            seg_copy = dict(seg)
+            seg_copy["channel"] = label
+            merged.append(seg_copy)
+
+    # Sort by start time (handle both string and numeric)
+    merged.sort(key=lambda s: float(s.get("start", 0)))
+    return merged
+
+
+def detect_channels_from_wav(file_path: str) -> int:
+    """Read channel count from a WAV file header.
+
+    Args:
+        file_path: Path to a .wav file.
+
+    Returns:
+        Number of channels, or 1 if detection fails.
+    """
+    try:
+        import wave
+        with wave.open(file_path, "rb") as wf:
+            return wf.getnchannels()
+    except Exception as e:
+        logging.warning(f"Could not detect channels from {file_path}: {e}")
+        return 1

--- a/whisper_live/pii_redaction.py
+++ b/whisper_live/pii_redaction.py
@@ -1,0 +1,87 @@
+"""
+PII (Personally Identifiable Information) redaction for transcription output.
+
+Uses regex patterns to detect and redact common PII types:
+- Social Security Numbers (SSN)
+- Credit/debit card numbers
+- Phone numbers (US formats)
+- Email addresses
+- IP addresses
+
+All redaction is applied as a post-processing step on transcription text.
+"""
+
+import re
+from typing import List, Optional, Set
+
+
+# Redaction placeholder per PII type
+_REDACTION_MAP = {
+    "ssn": "[SSN_REDACTED]",
+    "credit_card": "[CARD_REDACTED]",
+    "phone": "[PHONE_REDACTED]",
+    "email": "[EMAIL_REDACTED]",
+    "ip_address": "[IP_REDACTED]",
+}
+
+# Regex patterns for PII detection
+_PATTERNS = {
+    "ssn": re.compile(
+        r'\b\d{3}[-\s]?\d{2}[-\s]?\d{4}\b'
+    ),
+    "credit_card": re.compile(
+        r'\b(?:\d{4}[-\s]?){3}\d{4}\b'
+    ),
+    "phone": re.compile(
+        r'\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)?\d{3}[-.\s]?\d{4}\b'
+    ),
+    "email": re.compile(
+        r'\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b'
+    ),
+    "ip_address": re.compile(
+        r'\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b'
+    ),
+}
+
+ALL_PII_TYPES = set(_PATTERNS.keys())
+
+# Apply in this order: longer/more-specific patterns first
+_APPLICATION_ORDER = ["credit_card", "ssn", "ip_address", "email", "phone"]
+
+
+def redact_pii(
+    text: str,
+    pii_types: Optional[Set[str]] = None,
+    custom_patterns: Optional[dict] = None,
+) -> str:
+    """Redact PII from text using regex patterns.
+
+    Args:
+        text: Input text to redact.
+        pii_types: Set of PII types to redact. If None, redacts all types.
+            Valid types: "ssn", "credit_card", "phone", "email", "ip_address".
+        custom_patterns: Optional dict mapping label -> (compiled regex, replacement string).
+
+    Returns:
+        Text with PII replaced by redaction placeholders.
+    """
+    if not text:
+        return text
+
+    types_to_check = pii_types if pii_types is not None else ALL_PII_TYPES
+
+    # Apply in fixed order: longer patterns first to prevent partial matches
+    for pii_type in _APPLICATION_ORDER:
+        if pii_type in types_to_check and pii_type in _PATTERNS:
+            text = _PATTERNS[pii_type].sub(_REDACTION_MAP[pii_type], text)
+
+    if custom_patterns:
+        for label, (pattern, replacement) in custom_patterns.items():
+            text = pattern.sub(replacement, text)
+
+    return text
+
+
+def get_supported_pii_types() -> List[str]:
+    """Return list of supported PII type names."""
+    return sorted(ALL_PII_TYPES)

--- a/whisper_live/plugins.py
+++ b/whisper_live/plugins.py
@@ -1,0 +1,134 @@
+"""
+Plugin system for WhisperLive post-processing pipeline.
+
+Allows users to register custom post-processing plugins that run on
+transcription segments. Plugins are callables that accept a segment dict
+and return a modified segment dict.
+
+Usage:
+    from whisper_live.plugins import PluginRegistry
+
+    registry = PluginRegistry()
+
+    @registry.register("uppercase")
+    def uppercase_plugin(segment):
+        segment["text"] = segment["text"].upper()
+        return segment
+
+    # Or register without decorator:
+    registry.add("my_plugin", my_callable, priority=10)
+
+    # Apply all plugins to a segment
+    segment = registry.apply(segment)
+"""
+
+import logging
+from typing import Callable, Dict, List, Optional
+
+
+class PluginEntry:
+    """A registered plugin with metadata."""
+
+    __slots__ = ("name", "fn", "priority", "enabled")
+
+    def __init__(self, name: str, fn: Callable, priority: int = 50, enabled: bool = True):
+        self.name = name
+        self.fn = fn
+        self.priority = priority
+        self.enabled = enabled
+
+
+class PluginRegistry:
+    """Registry for post-processing plugins.
+
+    Plugins are applied in priority order (lower priority numbers run first).
+    Each plugin receives a segment dict and must return a segment dict.
+    """
+
+    def __init__(self):
+        self._plugins: Dict[str, PluginEntry] = {}
+
+    def add(self, name: str, fn: Callable, priority: int = 50, enabled: bool = True):
+        """Register a plugin.
+
+        Args:
+            name: Unique plugin name.
+            fn: Callable that takes a segment dict and returns a segment dict.
+            priority: Execution order (lower = earlier). Default 50.
+            enabled: Whether the plugin is active. Default True.
+
+        Raises:
+            ValueError: If a plugin with the same name is already registered.
+        """
+        if name in self._plugins:
+            raise ValueError(f"Plugin '{name}' is already registered")
+        self._plugins[name] = PluginEntry(name, fn, priority, enabled)
+
+    def register(self, name: str, priority: int = 50):
+        """Decorator to register a plugin function.
+
+        Args:
+            name: Unique plugin name.
+            priority: Execution order (lower = earlier). Default 50.
+        """
+        def decorator(fn):
+            self.add(name, fn, priority)
+            return fn
+        return decorator
+
+    def remove(self, name: str):
+        """Remove a plugin by name."""
+        self._plugins.pop(name, None)
+
+    def enable(self, name: str):
+        """Enable a plugin by name."""
+        if name in self._plugins:
+            self._plugins[name].enabled = True
+
+    def disable(self, name: str):
+        """Disable a plugin by name."""
+        if name in self._plugins:
+            self._plugins[name].enabled = False
+
+    def list_plugins(self) -> List[dict]:
+        """Return list of registered plugins with their metadata."""
+        return [
+            {"name": p.name, "priority": p.priority, "enabled": p.enabled}
+            for p in sorted(self._plugins.values(), key=lambda p: p.priority)
+        ]
+
+    def apply(self, segment: dict) -> dict:
+        """Apply all enabled plugins to a segment in priority order.
+
+        Args:
+            segment: Transcription segment dict with at least 'text', 'start', 'end'.
+
+        Returns:
+            Modified segment dict after all plugins have been applied.
+        """
+        ordered = sorted(
+            (p for p in self._plugins.values() if p.enabled),
+            key=lambda p: p.priority,
+        )
+        for plugin in ordered:
+            try:
+                result = plugin.fn(segment)
+                if result is not None:
+                    segment = result
+            except Exception as e:
+                logging.error(f"Plugin '{plugin.name}' failed: {e}")
+        return segment
+
+    def clear(self):
+        """Remove all registered plugins."""
+        self._plugins.clear()
+
+    def __len__(self):
+        return len(self._plugins)
+
+    def __contains__(self, name: str):
+        return name in self._plugins
+
+
+# Global default registry
+default_registry = PluginRegistry()

--- a/whisper_live/profanity_filter.py
+++ b/whisper_live/profanity_filter.py
@@ -1,0 +1,87 @@
+"""
+Profanity filter for transcription output.
+
+Masks or removes profane words from transcription text using a built-in
+word list. Supports configurable masking characters and partial/full masking
+modes.
+"""
+
+import re
+from typing import Optional, Set
+
+# Common English profanity word list (kept minimal and non-exhaustive)
+_DEFAULT_PROFANITY = {
+    "ass", "asshole", "bastard", "bitch", "bullshit", "cock", "crap",
+    "damn", "dick", "fuck", "fucking", "fucker", "goddamn", "hell",
+    "motherfucker", "motherfucking", "piss", "shit", "shitty", "whore",
+}
+
+
+def _build_pattern(words: Set[str]) -> re.Pattern:
+    """Build a compiled regex that matches any of the given words (case-insensitive)."""
+    escaped = sorted((re.escape(w) for w in words), key=len, reverse=True)
+    return re.compile(r'\b(' + '|'.join(escaped) + r')\b', re.IGNORECASE)
+
+
+_DEFAULT_PATTERN = _build_pattern(_DEFAULT_PROFANITY)
+
+
+def _mask_word(word: str, mask_char: str = "*", mode: str = "partial") -> str:
+    """Mask a profane word.
+
+    Args:
+        word: The matched profane word.
+        mask_char: Character used for masking.
+        mode: "partial" keeps first and last character, "full" masks entirely.
+
+    Returns:
+        Masked version of the word.
+    """
+    if mode == "full" or len(word) <= 2:
+        return mask_char * len(word)
+    return word[0] + mask_char * (len(word) - 2) + word[-1]
+
+
+def filter_profanity(
+    text: str,
+    mode: str = "partial",
+    mask_char: str = "*",
+    custom_words: Optional[Set[str]] = None,
+    extra_words: Optional[Set[str]] = None,
+) -> str:
+    """Filter profanity from text by masking offensive words.
+
+    Args:
+        text: Input text to filter.
+        mode: Masking mode - "partial" (f**k), "full" (****), or "remove".
+        mask_char: Character used for masking. Default "*".
+        custom_words: If provided, replaces the default profanity list entirely.
+        extra_words: If provided, adds to the default profanity list.
+
+    Returns:
+        Text with profanity masked or removed.
+    """
+    if not text:
+        return text
+
+    if custom_words is not None:
+        pattern = _build_pattern(custom_words)
+    elif extra_words:
+        pattern = _build_pattern(_DEFAULT_PROFANITY | extra_words)
+    else:
+        pattern = _DEFAULT_PATTERN
+
+    if mode == "remove":
+        # Remove the word and collapse extra spaces
+        result = pattern.sub("", text)
+        return re.sub(r' {2,}', ' ', result).strip()
+
+    def _replacer(match):
+        return _mask_word(match.group(0), mask_char=mask_char, mode=mode)
+
+    return pattern.sub(_replacer, text)
+
+
+def get_default_profanity_words() -> Set[str]:
+    """Return a copy of the default profanity word set."""
+    return set(_DEFAULT_PROFANITY)

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -296,6 +296,7 @@ class TranscriptionServer:
                     word_timestamps=options.get("word_timestamps", False),
                     hotwords=options.get("hotwords"),
                     diarization=self._create_diarizer(options),
+                    smart_formatting=options.get("smart_formatting", False),
                 )
 
                 logging.info("Running faster_whisper backend.")

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -534,6 +534,15 @@ class TranscriptionServer:
                     hotwords=hotwords,
                 )
 
+                # Emit metadata event with detected language info
+                meta = {
+                    "type": "metadata",
+                    "language": info.language,
+                    "language_probability": info.language_probability,
+                    "duration": info.duration,
+                }
+                yield f"data: {json.dumps(meta)}\n\n"
+
                 for seg in segments:
                     seg_dict = {
                         "id": seg.id,
@@ -905,11 +914,16 @@ class TranscriptionServer:
                         return PlainTextResponse(text)
                     elif response_format == "json":
                         wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
-                        return {"text": text}
+                        return {
+                            "text": text,
+                            "language": info.language,
+                            "language_probability": info.language_probability,
+                        }
                     elif response_format == "verbose_json":
                         verbose = {
                             "task": "transcribe",
                             "language": info.language,
+                            "language_probability": info.language_probability,
                             "duration": info.duration,
                             "text": text,
                             "segments": []
@@ -994,6 +1008,7 @@ class TranscriptionServer:
                     )
                     analysis["text"] = text
                     analysis["language"] = info.language
+                    analysis["language_probability"] = info.language_probability
                     analysis["duration"] = info.duration
                     wl_metrics.track_rest_request(endpoint="intelligence", status=200)
                     return analysis

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -12,7 +12,7 @@ from typing import Optional, List
 from fastapi import FastAPI, UploadFile, Form, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from starlette.responses import PlainTextResponse, JSONResponse
+from starlette.responses import PlainTextResponse, JSONResponse, StreamingResponse
 import uvicorn
 from faster_whisper import WhisperModel
 import torch
@@ -460,6 +460,59 @@ class TranscriptionServer:
             wl_metrics.track_connection_closed()
             del websocket
 
+    def _stream_transcription(self, file, language, prompt, temperature,
+                              timestamp_granularities, hotwords,
+                              faster_whisper_custom_model_path):
+        """Return a StreamingResponse that yields SSE events per segment."""
+
+        async def _sse_generator():
+            tmp_path = None
+            try:
+                suffix = os.path.splitext(file.filename)[1] or ".wav"
+                with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+                    shutil.copyfileobj(file.file, tmp)
+                    tmp_path = tmp.name
+
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+                compute_type = "float16" if device == "cuda" else "int8"
+                model_name = faster_whisper_custom_model_path or "small"
+                transcriber = WhisperModel(model_name, device=device, compute_type=compute_type)
+                segments, info = transcriber.transcribe(
+                    tmp_path,
+                    language=language,
+                    initial_prompt=prompt,
+                    temperature=temperature,
+                    vad_filter=False,
+                    word_timestamps=(timestamp_granularities and "word" in timestamp_granularities),
+                    hotwords=hotwords,
+                )
+
+                for seg in segments:
+                    seg_dict = {
+                        "id": seg.id,
+                        "start": seg.start,
+                        "end": seg.end,
+                        "text": seg.text.strip(),
+                    }
+                    if timestamp_granularities and "word" in timestamp_granularities:
+                        seg_dict["words"] = [
+                            {"word": w.word, "start": w.start, "end": w.end, "probability": w.probability}
+                            for w in seg.words
+                        ]
+                    yield f"data: {json.dumps(seg_dict)}\n\n"
+
+                yield "data: [DONE]\n\n"
+                wl_metrics.track_rest_request(endpoint="transcriptions_stream", status=200)
+            except Exception as e:
+                yield f"data: {json.dumps({'error': str(e)})}\n\n"
+                wl_metrics.track_rest_request(endpoint="transcriptions_stream", status=500)
+                wl_metrics.track_error("rest_stream")
+            finally:
+                if tmp_path and os.path.exists(tmp_path):
+                    os.unlink(tmp_path)
+
+        return StreamingResponse(_sse_generator(), media_type="text/event-stream")
+
     def run(self,
             host,
             port=9090,
@@ -601,8 +654,11 @@ class TranscriptionServer:
                 hotwords: Optional[str] = Form(default=None),
             ):
                 if stream:
-                    wl_metrics.track_rest_request(endpoint="transcriptions", status=400)
-                    return JSONResponse({"error": "Streaming not supported in this backend."}, status_code=400)
+                    return self._stream_transcription(
+                        file, language, prompt, temperature,
+                        timestamp_granularities, hotwords,
+                        faster_whisper_custom_model_path,
+                    )
 
                 ignored_params = []
                 if chunking_strategy:

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -18,6 +18,8 @@ from faster_whisper import WhisperModel
 import torch
 
 from enum import Enum
+
+from whisper_live import metrics as wl_metrics
 from typing import List, Optional
 import numpy as np
 from websockets.sync.server import serve
@@ -368,6 +370,7 @@ class TranscriptionServer:
 
             self.use_vad = options.get('use_vad')
             if self.client_manager.is_server_full(websocket, options):
+                wl_metrics.track_connection_rejected(reason="full")
                 websocket.close()
                 return False  # Indicates that the connection should not continue
 
@@ -375,6 +378,7 @@ class TranscriptionServer:
                 self.vad_detector = VoiceActivityDetector(frame_rate=self.RATE)
             self.initialize_client(websocket, options, faster_whisper_custom_model_path,
                                    whisper_tensorrt_path, trt_multilingual, trt_py_session=trt_py_session)
+            wl_metrics.track_connection_opened()
             return True
         except json.JSONDecodeError:
             logging.error("Failed to decode JSON from client")
@@ -453,6 +457,7 @@ class TranscriptionServer:
             if self.client_manager.get_client(websocket):
                 self.cleanup(websocket)
                 websocket.close()
+            wl_metrics.track_connection_closed()
             del websocket
 
     def run(self,
@@ -475,7 +480,8 @@ class TranscriptionServer:
             batch_window_ms=50,
             raw_pcm_input=False,
             api_key: Optional[str] = None,
-            rate_limit_rpm: int = 0):
+            rate_limit_rpm: int = 0,
+            metrics_port: int = 0):
         """
         Run the transcription server.
 
@@ -531,6 +537,10 @@ class TranscriptionServer:
                 logging.info("Single model mode currently only works with custom models.")
         if not BackendType.is_valid(backend):
             raise ValueError(f"{backend} is not a valid backend type. Choose backend from {BackendType.valid_types()}")
+
+        # Start Prometheus metrics endpoint if port is specified
+        if metrics_port > 0:
+            wl_metrics.start_metrics_server(metrics_port)
 
         # New OpenAI-compatible REST API (toggleable via enable_rest boolean)
         if enable_rest:
@@ -591,6 +601,7 @@ class TranscriptionServer:
                 hotwords: Optional[str] = Form(default=None),
             ):
                 if stream:
+                    wl_metrics.track_rest_request(endpoint="transcriptions", status=400)
                     return JSONResponse({"error": "Streaming not supported in this backend."}, status_code=400)
 
                 ignored_params = []
@@ -607,6 +618,7 @@ class TranscriptionServer:
 
                 supported_formats = ["json", "text", "srt", "verbose_json", "vtt"]
                 if response_format not in supported_formats:
+                    wl_metrics.track_rest_request(endpoint="transcriptions", status=400)
                     return JSONResponse({"error": f"Unsupported response_format. Supported: {supported_formats}"}, status_code=400)
 
                 if model != "whisper-1":
@@ -637,8 +649,10 @@ class TranscriptionServer:
                     os.unlink(tmp_path)
 
                     if response_format == "text":
+                        wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
                         return PlainTextResponse(text)
                     elif response_format == "json":
+                        wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
                         return {"text": text}
                     elif response_format == "verbose_json":
                         verbose = {
@@ -664,6 +678,7 @@ class TranscriptionServer:
                             if timestamp_granularities and "word" in timestamp_granularities:
                                 seg_dict["words"] = [{"word": w.word, "start": w.start, "end": w.end, "probability": w.probability} for w in seg.words]
                             verbose["segments"].append(seg_dict)
+                        wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
                         return verbose
                     elif response_format in ["srt", "vtt"]:
                         output = []
@@ -674,8 +689,11 @@ class TranscriptionServer:
                                 output.append(f"{i}\n{start.replace('.', ',')} --> {end.replace('.', ',')}\n{seg.text.strip()}\n")
                             else:  # vtt
                                 output.append(f"{start} --> {end}\n{seg.text.strip()}\n")
+                        wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
                         return PlainTextResponse("\n".join(output))
                 except Exception as e:
+                    wl_metrics.track_rest_request(endpoint="transcriptions", status=500)
+                    wl_metrics.track_error("rest_transcription")
                     return JSONResponse({"error": str(e)}, status_code=500)
 
             threading.Thread(
@@ -699,6 +717,7 @@ class TranscriptionServer:
                     token_param = parse_qs(parsed.query).get("token", [None])[0]
                 if auth == f"Bearer {api_key}" or token_param == api_key:
                     return None  # Allow connection
+                wl_metrics.track_connection_rejected(reason="auth")
                 return (401, [("Content-Type", "text/plain")], b"Unauthorized\n")
             extra_ws_kwargs["process_request"] = _ws_auth
 

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -468,6 +468,16 @@ class TranscriptionServer:
         """
         self.cache_path = cache_path
         self.raw_pcm_input = raw_pcm_input
+
+        if max_clients < 1:
+            raise ValueError(f"max_clients must be >= 1, got {max_clients}")
+        if max_connection_time <= 0:
+            raise ValueError(f"max_connection_time must be > 0, got {max_connection_time}")
+        if batch_enabled and batch_max_size < 1:
+            raise ValueError(f"batch_max_size must be >= 1, got {batch_max_size}")
+        if batch_enabled and batch_window_ms < 0:
+            raise ValueError(f"batch_window_ms must be >= 0, got {batch_window_ms}")
+
         self.client_manager = ClientManager(max_clients, max_connection_time)
         if faster_whisper_custom_model_path is not None and not os.path.exists(faster_whisper_custom_model_path):
             if "/" not in faster_whisper_custom_model_path:

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -653,6 +653,7 @@ class TranscriptionServer:
                 known_speaker_references: Optional[List[str]] = Form(default=None),
                 stream: bool = Form(default=False),
                 hotwords: Optional[str] = Form(default=None),
+                callback_url: Optional[str] = Form(default=None),
             ):
                 if stream:
                     return self._stream_transcription(
@@ -660,6 +661,62 @@ class TranscriptionServer:
                         timestamp_granularities, hotwords,
                         faster_whisper_custom_model_path,
                     )
+
+                if callback_url:
+                    import uuid as _uuid
+                    import urllib.request
+                    job_id = str(_uuid.uuid4())
+                    suffix = os.path.splitext(file.filename)[1] or ".wav"
+                    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+                    shutil.copyfileobj(file.file, tmp)
+                    tmp_path = tmp.name
+                    tmp.close()
+
+                    def _run_async_job():
+                        try:
+                            device = "cuda" if torch.cuda.is_available() else "cpu"
+                            compute_type = "float16" if device == "cuda" else "int8"
+                            model_name = faster_whisper_custom_model_path or "small"
+                            transcriber = WhisperModel(model_name, device=device, compute_type=compute_type)
+                            segments, info = transcriber.transcribe(
+                                tmp_path,
+                                language=language,
+                                initial_prompt=prompt,
+                                temperature=temperature,
+                                vad_filter=False,
+                                word_timestamps=(timestamp_granularities and "word" in timestamp_granularities),
+                                hotwords=hotwords,
+                            )
+                            text = " ".join([s.text.strip() for s in segments])
+                            payload = json.dumps({"job_id": job_id, "text": text}).encode()
+                            req = urllib.request.Request(
+                                callback_url,
+                                data=payload,
+                                headers={"Content-Type": "application/json"},
+                                method="POST",
+                            )
+                            urllib.request.urlopen(req, timeout=30)
+                            wl_metrics.track_rest_request(endpoint="transcriptions_async", status=200)
+                        except Exception as e:
+                            logging.error(f"Async job {job_id} failed: {e}")
+                            wl_metrics.track_error("async_job")
+                            try:
+                                err_payload = json.dumps({"job_id": job_id, "error": str(e)}).encode()
+                                req = urllib.request.Request(
+                                    callback_url,
+                                    data=err_payload,
+                                    headers={"Content-Type": "application/json"},
+                                    method="POST",
+                                )
+                                urllib.request.urlopen(req, timeout=30)
+                            except Exception:
+                                logging.error(f"Failed to send error callback for job {job_id}")
+                        finally:
+                            if os.path.exists(tmp_path):
+                                os.unlink(tmp_path)
+
+                    threading.Thread(target=_run_async_job, daemon=True).start()
+                    return JSONResponse({"job_id": job_id, "status": "processing"}, status_code=202)
 
                 ignored_params = []
                 if chunking_strategy:

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -514,6 +514,88 @@ class TranscriptionServer:
 
         return StreamingResponse(_sse_generator(), media_type="text/event-stream")
 
+    def _multichannel_transcribe(self, file, language, prompt, temperature,
+                                  timestamp_granularities, hotwords,
+                                  faster_whisper_custom_model_path,
+                                  channel_labels_str):
+        """Transcribe each audio channel independently and return merged results."""
+        from whisper_live.multichannel import detect_channels_from_wav, split_channels, merge_channel_segments
+        import soundfile as sf
+
+        tmp_path = None
+        try:
+            suffix = os.path.splitext(file.filename)[1] or ".wav"
+            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+                shutil.copyfileobj(file.file, tmp)
+                tmp_path = tmp.name
+
+            # Read audio with soundfile for proper channel handling
+            audio_data, sample_rate = sf.read(tmp_path, dtype="float32")
+            if audio_data.ndim == 1:
+                num_channels = 1
+                channel_arrays = [audio_data]
+            else:
+                num_channels = audio_data.shape[1]
+                channel_arrays = [audio_data[:, ch] for ch in range(num_channels)]
+
+            labels = None
+            if channel_labels_str:
+                labels = [l.strip() for l in channel_labels_str.split(",")]
+
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+            compute_type = "float16" if device == "cuda" else "int8"
+            model_name = faster_whisper_custom_model_path or "small"
+            transcriber = WhisperModel(model_name, device=device, compute_type=compute_type)
+
+            all_channel_segments = []
+            for ch_idx, ch_audio in enumerate(channel_arrays):
+                # Write each channel to a temp mono file
+                ch_tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
+                sf.write(ch_tmp.name, ch_audio, sample_rate)
+                ch_tmp.close()
+
+                segments, info = transcriber.transcribe(
+                    ch_tmp.name,
+                    language=language,
+                    initial_prompt=prompt,
+                    temperature=temperature,
+                    vad_filter=False,
+                    word_timestamps=(timestamp_granularities and "word" in timestamp_granularities),
+                    hotwords=hotwords,
+                )
+
+                ch_segs = []
+                for seg in segments:
+                    seg_dict = {
+                        "start": seg.start,
+                        "end": seg.end,
+                        "text": seg.text.strip(),
+                    }
+                    if timestamp_granularities and "word" in timestamp_granularities:
+                        seg_dict["words"] = [
+                            {"word": w.word, "start": w.start, "end": w.end, "probability": w.probability}
+                            for w in seg.words
+                        ]
+                    ch_segs.append(seg_dict)
+
+                all_channel_segments.append(ch_segs)
+                os.unlink(ch_tmp.name)
+
+            merged = merge_channel_segments(all_channel_segments, labels)
+            wl_metrics.track_rest_request(endpoint="transcriptions_multichannel", status=200)
+            return {
+                "channels": num_channels,
+                "segments": merged,
+                "text": " ".join(seg["text"] for seg in merged),
+            }
+        except Exception as e:
+            wl_metrics.track_rest_request(endpoint="transcriptions_multichannel", status=500)
+            wl_metrics.track_error("multichannel")
+            return JSONResponse({"error": str(e)}, status_code=500)
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
     def run(self,
             host,
             port=9090,
@@ -654,6 +736,8 @@ class TranscriptionServer:
                 stream: bool = Form(default=False),
                 hotwords: Optional[str] = Form(default=None),
                 callback_url: Optional[str] = Form(default=None),
+                multichannel: bool = Form(default=False),
+                channel_labels: Optional[str] = Form(default=None),
             ):
                 if stream:
                     return self._stream_transcription(
@@ -717,6 +801,14 @@ class TranscriptionServer:
 
                     threading.Thread(target=_run_async_job, daemon=True).start()
                     return JSONResponse({"job_id": job_id, "status": "processing"}, status_code=202)
+
+                if multichannel:
+                    return self._multichannel_transcribe(
+                        file, language, prompt, temperature,
+                        timestamp_granularities, hotwords,
+                        faster_whisper_custom_model_path,
+                        channel_labels,
+                    )
 
                 ignored_params = []
                 if chunking_strategy:

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -667,6 +667,21 @@ class TranscriptionServer:
             logging.info(f"✅ OpenAI-Compatible API started on http://0.0.0.0:{rest_port}")
 
         # Original WebSocket server (always supported)
+        extra_ws_kwargs = {}
+        if api_key:
+            def _ws_auth(path, request_headers):
+                auth = request_headers.get("Authorization", "")
+                token_param = None
+                # Check query string for token parameter
+                if "?" in path:
+                    from urllib.parse import urlparse, parse_qs
+                    parsed = urlparse(path)
+                    token_param = parse_qs(parsed.query).get("token", [None])[0]
+                if auth == f"Bearer {api_key}" or token_param == api_key:
+                    return None  # Allow connection
+                return (401, [("Content-Type", "text/plain")], b"Unauthorized\n")
+            extra_ws_kwargs["process_request"] = _ws_auth
+
         with serve(
             functools.partial(
                 self.recv_audio,
@@ -677,7 +692,8 @@ class TranscriptionServer:
                 trt_py_session=trt_py_session,
             ),
             host,
-            port
+            port,
+            **extra_ws_kwargs,
         ) as server:
             server.serve_forever()
 

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -921,6 +921,60 @@ class TranscriptionServer:
                     wl_metrics.track_error("rest_transcription")
                     return JSONResponse({"error": str(e)}, status_code=500)
 
+            @app.post("/v1/audio/intelligence")
+            async def intelligence_endpoint(
+                file: UploadFile,
+                model: str = Form(default="whisper-1"),
+                language: Optional[str] = Form(default=None),
+                prompt: Optional[str] = Form(default=None),
+                temperature: float = Form(default=0.0),
+                sentiment: bool = Form(default=True),
+                topics: bool = Form(default=True),
+                entities: bool = Form(default=True),
+                summary: bool = Form(default=True),
+                summary_sentences: int = Form(default=3),
+                topic_count: int = Form(default=5),
+            ):
+                from whisper_live.audio_intelligence import analyze_transcript
+                try:
+                    suffix = os.path.splitext(file.filename)[1] or ".wav"
+                    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+                        shutil.copyfileobj(file.file, tmp)
+                        tmp_path = tmp.name
+
+                    device = "cuda" if torch.cuda.is_available() else "cpu"
+                    compute_type = "float16" if device == "cuda" else "int8"
+                    model_name = faster_whisper_custom_model_path or "small"
+                    transcriber = WhisperModel(model_name, device=device, compute_type=compute_type)
+                    segments, info = transcriber.transcribe(
+                        tmp_path,
+                        language=language,
+                        initial_prompt=prompt,
+                        temperature=temperature,
+                        vad_filter=False,
+                    )
+                    text = " ".join([s.text.strip() for s in segments])
+                    os.unlink(tmp_path)
+
+                    analysis = analyze_transcript(
+                        text,
+                        sentiment=sentiment,
+                        topics=topics,
+                        entities=entities,
+                        summary=summary,
+                        summary_sentences=summary_sentences,
+                        topic_count=topic_count,
+                    )
+                    analysis["text"] = text
+                    analysis["language"] = info.language
+                    analysis["duration"] = info.duration
+                    wl_metrics.track_rest_request(endpoint="intelligence", status=200)
+                    return analysis
+                except Exception as e:
+                    wl_metrics.track_rest_request(endpoint="intelligence", status=500)
+                    wl_metrics.track_error("intelligence")
+                    return JSONResponse({"error": str(e)}, status_code=500)
+
             threading.Thread(
                 target=uvicorn.run,
                 args=(app,),

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -298,6 +298,7 @@ class TranscriptionServer:
                     diarization=self._create_diarizer(options),
                     smart_formatting=options.get("smart_formatting", False),
                     pii_redaction=self._parse_pii_option(options),
+                    profanity_filter=self._parse_profanity_option(options),
                 )
 
                 logging.info("Running faster_whisper backend.")
@@ -361,6 +362,32 @@ class TranscriptionServer:
             return set(pii)
         if isinstance(pii, str):
             return {t.strip() for t in pii.split(",") if t.strip()}
+        return None
+
+    def _parse_profanity_option(self, options):
+        """Parse profanity filter option from client handshake.
+
+        Returns:
+            dict of kwargs for filter_profanity(), or None if disabled.
+        """
+        pf = options.get("profanity_filter")
+        if not pf:
+            return None
+        if pf is True:
+            return {"mode": "partial"}
+        if isinstance(pf, str):
+            if pf in ("partial", "full", "remove"):
+                return {"mode": pf}
+            return {"mode": "partial"}
+        if isinstance(pf, dict):
+            result = {"mode": pf.get("mode", "partial")}
+            if "mask_char" in pf:
+                result["mask_char"] = pf["mask_char"]
+            if "extra_words" in pf:
+                result["extra_words"] = set(pf["extra_words"])
+            if "custom_words" in pf:
+                result["custom_words"] = set(pf["custom_words"])
+            return result
         return None
 
     def get_audio_from_websocket(self, websocket):

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -160,6 +160,7 @@ class TranscriptionServer:
         self.use_vad = True
         self.single_model = False
         self.batch_config = None
+        self.raw_pcm_input = False
 
     def initialize_client(
         self, websocket, options, faster_whisper_custom_model_path,
@@ -316,6 +317,9 @@ class TranscriptionServer:
         frame_data = websocket.recv()
         if frame_data == b"END_OF_AUDIO":
             return False
+        if self.raw_pcm_input:
+            audio_np = np.frombuffer(frame_data, dtype=np.int16)
+            return audio_np.astype(np.float32) / 32768.0
         return np.frombuffer(frame_data, dtype=np.float32)
 
     def handle_new_connection(self, websocket, faster_whisper_custom_model_path,
@@ -431,7 +435,8 @@ class TranscriptionServer:
             cors_origins: Optional[str] = None,
             batch_enabled=False,
             batch_max_size=8,
-            batch_window_ms=50):
+            batch_window_ms=50,
+            raw_pcm_input=False):
         """
         Run the transcription server.
 
@@ -449,6 +454,7 @@ class TranscriptionServer:
                 to 50.
         """
         self.cache_path = cache_path
+        self.raw_pcm_input = raw_pcm_input
         self.client_manager = ClientManager(max_clients, max_connection_time)
         if faster_whisper_custom_model_path is not None and not os.path.exists(faster_whisper_custom_model_path):
             if "/" not in faster_whisper_custom_model_path:

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -297,6 +297,7 @@ class TranscriptionServer:
                     hotwords=options.get("hotwords"),
                     diarization=self._create_diarizer(options),
                     smart_formatting=options.get("smart_formatting", False),
+                    pii_redaction=self._parse_pii_option(options),
                 )
 
                 logging.info("Running faster_whisper backend.")
@@ -343,6 +344,24 @@ class TranscriptionServer:
         except ImportError:
             logging.warning("pyannote.audio not installed; diarization disabled")
             return None
+
+    def _parse_pii_option(self, options):
+        """Parse PII redaction option from client handshake.
+
+        Returns:
+            set of PII type strings, or None if disabled.
+        """
+        pii = options.get("pii_redaction")
+        if not pii:
+            return None
+        if pii is True or pii == "all":
+            from whisper_live.pii_redaction import ALL_PII_TYPES
+            return ALL_PII_TYPES
+        if isinstance(pii, list):
+            return set(pii)
+        if isinstance(pii, str):
+            return {t.strip() for t in pii.split(",") if t.strip()}
+        return None
 
     def get_audio_from_websocket(self, websocket):
         """

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -735,7 +735,20 @@ class TranscriptionServer:
 
         # New OpenAI-compatible REST API (toggleable via enable_rest boolean)
         if enable_rest:
-            app = FastAPI(title="WhisperLive OpenAI-Compatible API")
+            app = FastAPI(
+                title="WhisperLive OpenAI-Compatible API",
+                description=(
+                    "Real-time and batch speech-to-text transcription API. "
+                    "Compatible with the OpenAI Audio API format. "
+                    "Supports streaming (SSE), webhooks, multi-channel audio, "
+                    "speaker diarization, PII redaction, profanity filtering, "
+                    "and audio intelligence analysis."
+                ),
+                version="0.9.0",
+                docs_url="/docs",
+                redoc_url="/redoc",
+                openapi_url="/openapi.json",
+            )
             origins = [o.strip() for o in cors_origins.split(',')] if cors_origins else []
             app.add_middleware(
                 CORSMiddleware,
@@ -774,7 +787,22 @@ class TranscriptionServer:
                     return await call_next(request)
 
 
-            @app.post("/v1/audio/transcriptions")
+            @app.get("/health", tags=["System"],
+                     summary="Health check",
+                     description="Returns server health status and connected client count.")
+            async def health_check():
+                client_count = len(self.client_manager.clients) if self.client_manager else 0
+                return {
+                    "status": "ok",
+                    "clients": client_count,
+                    "max_clients": self.client_manager.max_clients if self.client_manager else 0,
+                }
+
+            @app.post("/v1/audio/transcriptions", tags=["Transcription"],
+                      summary="Transcribe audio file",
+                      description="Transcribe an audio file. Supports JSON, text, SRT, VTT, "
+                                  "verbose_json response formats. Optional SSE streaming, "
+                                  "webhook callbacks, and multi-channel mode.")
             async def transcribe(
                 file: UploadFile,
                 model: str = Form(default="whisper-1"),
@@ -962,7 +990,10 @@ class TranscriptionServer:
                     wl_metrics.track_error("rest_transcription")
                     return JSONResponse({"error": str(e)}, status_code=500)
 
-            @app.post("/v1/audio/intelligence")
+            @app.post("/v1/audio/intelligence", tags=["Intelligence"],
+                      summary="Analyze transcript",
+                      description="Transcribe audio and perform NLP analysis: "
+                                  "sentiment, topic detection, entity extraction, and summarization.")
             async def intelligence_endpoint(
                 file: UploadFile,
                 model: str = Form(default="whisper-1"),

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -292,6 +292,7 @@ class TranscriptionServer:
                     cache_path=self.cache_path,
                     translation_queue=translation_queue,
                     word_timestamps=options.get("word_timestamps", False),
+                    hotwords=options.get("hotwords"),
                 )
 
                 logging.info("Running faster_whisper backend.")
@@ -566,7 +567,8 @@ class TranscriptionServer:
                 include: Optional[List[str]] = Form(default=None),
                 known_speaker_names: Optional[List[str]] = Form(default=None),
                 known_speaker_references: Optional[List[str]] = Form(default=None),
-                stream: bool = Form(default=False)
+                stream: bool = Form(default=False),
+                hotwords: Optional[str] = Form(default=None),
             ):
                 if stream:
                     return JSONResponse({"error": "Streaming not supported in this backend."}, status_code=400)
@@ -607,7 +609,8 @@ class TranscriptionServer:
                         initial_prompt=prompt,
                         temperature=temperature,
                         vad_filter=False,
-                        word_timestamps=(timestamp_granularities and "word" in timestamp_granularities)
+                        word_timestamps=(timestamp_granularities and "word" in timestamp_granularities),
+                        hotwords=hotwords,
                     )
 
                     text = " ".join([s.text.strip() for s in segments])

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -290,7 +290,8 @@ class TranscriptionServer:
                     clip_audio=options.get("clip_audio", False),
                     same_output_threshold=options.get("same_output_threshold", 10),
                     cache_path=self.cache_path,
-                    translation_queue=translation_queue
+                    translation_queue=translation_queue,
+                    word_timestamps=options.get("word_timestamps", False),
                 )
 
                 logging.info("Running faster_whisper backend.")

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -537,8 +537,18 @@ class TranscriptionServer:
             ):
                 if stream:
                     return JSONResponse({"error": "Streaming not supported in this backend."}, status_code=400)
-                if chunking_strategy or known_speaker_names or known_speaker_references:
-                    logging.warning("Diarization/chunking params ignored; not supported.")
+
+                ignored_params = []
+                if chunking_strategy:
+                    ignored_params.append(f"chunking_strategy='{chunking_strategy}'")
+                if known_speaker_names:
+                    ignored_params.append("known_speaker_names")
+                if known_speaker_references:
+                    ignored_params.append("known_speaker_references")
+                if include:
+                    ignored_params.append(f"include={include}")
+                if ignored_params:
+                    logging.warning(f"Unsupported OpenAI params ignored: {', '.join(ignored_params)}")
 
                 supported_formats = ["json", "text", "srt", "verbose_json", "vtt"]
                 if response_format not in supported_formats:

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -1,6 +1,7 @@
 import os
 import time
 import threading
+import collections
 import queue
 import json
 import functools
@@ -8,8 +9,9 @@ import logging
 import shutil
 import tempfile
 from typing import Optional, List
-from fastapi import FastAPI, UploadFile, Form
+from fastapi import FastAPI, UploadFile, Form, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from starlette.responses import PlainTextResponse, JSONResponse
 import uvicorn
 from faster_whisper import WhisperModel
@@ -449,7 +451,9 @@ class TranscriptionServer:
             batch_enabled=False,
             batch_max_size=8,
             batch_window_ms=50,
-            raw_pcm_input=False):
+            raw_pcm_input=False,
+            api_key: Optional[str] = None,
+            rate_limit_rpm: int = 0):
         """
         Run the transcription server.
 
@@ -517,6 +521,34 @@ class TranscriptionServer:
                 allow_methods=["*"],  # Allows all methods (GET, POST, etc.)
                 allow_headers=["*"],  # Allows all headers
             )
+
+            # Optional API key authentication
+            if api_key:
+                @app.middleware("http")
+                async def _check_api_key(request: Request, call_next):
+                    auth = request.headers.get("Authorization", "")
+                    if auth != f"Bearer {api_key}":
+                        return JSONResponse({"error": "Invalid or missing API key"}, status_code=401)
+                    return await call_next(request)
+
+            # Optional rate limiting (requests per minute per client IP)
+            if rate_limit_rpm > 0:
+                _rate_lock = threading.Lock()
+                _rate_buckets: dict = {}  # ip -> deque of timestamps
+
+                @app.middleware("http")
+                async def _rate_limit(request: Request, call_next):
+                    client_ip = request.client.host if request.client else "unknown"
+                    now = time.time()
+                    with _rate_lock:
+                        bucket = _rate_buckets.setdefault(client_ip, collections.deque())
+                        # Discard entries older than 60s
+                        while bucket and bucket[0] < now - 60:
+                            bucket.popleft()
+                        if len(bucket) >= rate_limit_rpm:
+                            return JSONResponse({"error": "Rate limit exceeded"}, status_code=429)
+                        bucket.append(now)
+                    return await call_next(request)
 
 
             @app.post("/v1/audio/transcriptions")

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -191,7 +191,7 @@ class TranscriptionServer:
         
         if enable_translation:
             target_language = options.get("target_language", "fr")
-            translation_queue = queue.Queue()
+            translation_queue = queue.Queue(maxsize=ServeClientBase.MAX_TRANSLATION_QUEUE_SIZE)
             from whisper_live.backend.translation_backend import ServeClientTranslation
             translation_client = ServeClientTranslation(
                 client_uid=options["uid"],

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -293,6 +293,7 @@ class TranscriptionServer:
                     translation_queue=translation_queue,
                     word_timestamps=options.get("word_timestamps", False),
                     hotwords=options.get("hotwords"),
+                    diarization=self._create_diarizer(options),
                 )
 
                 logging.info("Running faster_whisper backend.")
@@ -320,6 +321,25 @@ class TranscriptionServer:
             client.translation_thread = translation_thread
 
         self.client_manager.add_client(websocket, client)
+
+    def _create_diarizer(self, options):
+        """Create a SpeakerDiarizer if the client requested diarization.
+
+        Returns:
+            SpeakerDiarizer or None
+        """
+        if not options.get("enable_diarization", False):
+            return None
+        try:
+            from whisper_live.diarization import SpeakerDiarizer
+            return SpeakerDiarizer(
+                similarity_threshold=options.get("diarization_threshold", 0.55),
+                max_speakers=options.get("max_speakers", 10),
+                hf_token=options.get("hf_token"),
+            )
+        except ImportError:
+            logging.warning("pyannote.audio not installed; diarization disabled")
+            return None
 
     def get_audio_from_websocket(self, websocket):
         """

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -178,6 +178,7 @@ class TranscriptionServer:
         self.single_model = False
         self.batch_config = None
         self.raw_pcm_input = False
+        self.plugin_registry = None
 
     def initialize_client(
         self, websocket, options, faster_whisper_custom_model_path,
@@ -302,6 +303,9 @@ class TranscriptionServer:
                 )
 
                 logging.info("Running faster_whisper backend.")
+
+                if self.plugin_registry:
+                    client.plugin_registry = self.plugin_registry
 
                 # Start batch inference worker on first client (after model is loaded)
                 if (self.batch_config is not None
@@ -672,7 +676,8 @@ class TranscriptionServer:
             raw_pcm_input=False,
             api_key: Optional[str] = None,
             rate_limit_rpm: int = 0,
-            metrics_port: int = 0):
+            metrics_port: int = 0,
+            plugin_registry=None):
         """
         Run the transcription server.
 
@@ -691,6 +696,7 @@ class TranscriptionServer:
         """
         self.cache_path = cache_path
         self.raw_pcm_input = raw_pcm_input
+        self.plugin_registry = plugin_registry
 
         if max_clients < 1:
             raise ValueError(f"max_clients must be >= 1, got {max_clients}")
@@ -797,6 +803,14 @@ class TranscriptionServer:
                     "clients": client_count,
                     "max_clients": self.client_manager.max_clients if self.client_manager else 0,
                 }
+
+            @app.get("/v1/plugins", tags=["System"],
+                     summary="List plugins",
+                     description="Returns the list of registered post-processing plugins.")
+            async def list_plugins():
+                if self.plugin_registry:
+                    return {"plugins": self.plugin_registry.list_plugins()}
+                return {"plugins": []}
 
             @app.post("/v1/audio/transcriptions", tags=["Transcription"],
                       summary="Transcribe audio file",

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -39,6 +39,7 @@ class ClientManager:
         self.start_times = {}
         self.max_clients = max_clients
         self.max_connection_time = max_connection_time
+        self.lock = threading.Lock()
 
     def add_client(self, websocket, client):
         """
@@ -48,8 +49,9 @@ class ClientManager:
             websocket: The websocket associated with the client to add.
             client: The client object to be added and tracked.
         """
-        self.clients[websocket] = client
-        self.start_times[websocket] = time.time()
+        with self.lock:
+            self.clients[websocket] = client
+            self.start_times[websocket] = time.time()
 
     def get_client(self, websocket):
         """
@@ -61,9 +63,10 @@ class ClientManager:
         Returns:
             The client object if found, False otherwise.
         """
-        if websocket in self.clients:
-            return self.clients[websocket]
-        return False
+        with self.lock:
+            if websocket in self.clients:
+                return self.clients[websocket]
+            return False
 
     def remove_client(self, websocket):
         """
@@ -73,10 +76,11 @@ class ClientManager:
         Args:
             websocket: The websocket associated with the client to be removed.
         """
-        client = self.clients.pop(websocket, None)
+        with self.lock:
+            client = self.clients.pop(websocket, None)
+            self.start_times.pop(websocket, None)
         if client:
             client.cleanup()
-        self.start_times.pop(websocket, None)
 
     def get_wait_time(self):
         """
@@ -85,11 +89,12 @@ class ClientManager:
         Returns:
             The estimated wait time in minutes for new clients to connect. Returns 0 if there are available slots.
         """
-        wait_time = None
-        for start_time in self.start_times.values():
-            current_client_time_remaining = self.max_connection_time - (time.time() - start_time)
-            if wait_time is None or current_client_time_remaining < wait_time:
-                wait_time = current_client_time_remaining
+        with self.lock:
+            wait_time = None
+            for start_time in self.start_times.values():
+                current_client_time_remaining = self.max_connection_time - (time.time() - start_time)
+                if wait_time is None or current_client_time_remaining < wait_time:
+                    wait_time = current_client_time_remaining
         return wait_time / 60 if wait_time is not None else 0
 
     def is_server_full(self, websocket, options):
@@ -103,12 +108,18 @@ class ClientManager:
         Returns:
             True if the server is full, False otherwise.
         """
-        if len(self.clients) >= self.max_clients:
-            wait_time = self.get_wait_time()
-            response = {"uid": options["uid"], "status": "WAIT", "message": wait_time}
-            websocket.send(json.dumps(response))
-            return True
-        return False
+        with self.lock:
+            if len(self.clients) >= self.max_clients:
+                wait_time = None
+                for start_time in self.start_times.values():
+                    remaining = self.max_connection_time - (time.time() - start_time)
+                    if wait_time is None or remaining < wait_time:
+                        wait_time = remaining
+                wait_time_minutes = wait_time / 60 if wait_time is not None else 0
+                response = {"uid": options["uid"], "status": "WAIT", "message": wait_time_minutes}
+                websocket.send(json.dumps(response))
+                return True
+            return False
 
     def is_client_timeout(self, websocket):
         """
@@ -120,10 +131,12 @@ class ClientManager:
         Returns:
             True if the client's connection time has exceeded the maximum limit, False otherwise.
         """
-        elapsed_time = time.time() - self.start_times[websocket]
-        if elapsed_time >= self.max_connection_time:
-            self.clients[websocket].disconnect()
-            logging.warning(f"Client with uid '{self.clients[websocket].client_uid}' disconnected due to overtime.")
+        with self.lock:
+            elapsed_time = time.time() - self.start_times[websocket]
+            client = self.clients.get(websocket)
+        if elapsed_time >= self.max_connection_time and client:
+            client.disconnect()
+            logging.warning(f"Client with uid '{client.client_uid}' disconnected due to overtime.")
             return True
         return False
 

--- a/whisper_live/utils.py
+++ b/whisper_live/utils.py
@@ -1,4 +1,3 @@
-import os
 import textwrap
 import scipy
 import numpy as np
@@ -8,7 +7,7 @@ from pathlib import Path
 
 def clear_screen():
     """Clears the console screen."""
-    os.system("cls" if os.name == "nt" else "clear")
+    print("\033[H\033[2J", end="", flush=True)
 
 
 def print_transcript(text, translated=False, timestamps=False):


### PR DESCRIPTION
- New whisper_live/plugins.py with PluginRegistry class
- Priority-ordered plugin execution on transcription segments
- Decorator and programmatic registration API
- Enable/disable/remove/list plugins at runtime
- Graceful error handling for failing plugins
- Server passes plugin_registry to backends, REST /v1/plugins endpoint
- 20 tests passing