### PR TITLE
ci: test package install in a virtual environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,27 @@ jobs:
           echo "Running tests with Python ${{ matrix.python-version }}"
           python -m unittest discover -s tests
   
+  test-install-in-venv:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.12
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y portaudio19-dev
+
+      - name: Create virtual environment and install package
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install .
+          python -c "import whisper_live; print(whisper_live.__version__)"
+
   check-code-format:
     runs-on: ubuntu-22.04
     strategy:


### PR DESCRIPTION
Fixes #329\n\n## Summary\n- add a CI job that creates a fresh Python 3.12 virtual environment\n- install the package into that venv\n- verify the installed package can be imported\n\nThis keeps the existing test matrix intact while adding a packaging smoke test closer to the reported venv workflow.