### PR TITLE
test: add clean virtualenv install smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,31 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
+  venv-install-smoke-test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.12'
+
+      - name: Build package artifacts
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+          python -m build --sdist --wheel
+
+      - name: Verify install in a clean virtualenv
+        run: |
+          python -m venv smoke-test-venv
+          source smoke-test-venv/bin/activate
+          pip install --no-deps dist/*.whl
+          python -c "import whisper_live"
+
   build-and-push-docker-cpu:
-    needs: [run-tests, check-code-format]
+    needs: [run-tests, check-code-format, venv-install-smoke-test]
     runs-on: ubuntu-22.04
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y portaudio19-dev
+
       - name: Build package artifacts
         run: |
           python -m pip install --upgrade pip
@@ -94,8 +97,8 @@ jobs:
         run: |
           python -m venv smoke-test-venv
           source smoke-test-venv/bin/activate
-          pip install --no-deps dist/*.whl
-          python -c "import whisper_live"
+          pip install dist/*.whl
+          python -c "import whisper_live.client; import whisper_live.server"
 
   build-and-push-docker-cpu:
     needs: [run-tests, check-code-format, venv-install-smoke-test]
@@ -181,7 +184,7 @@ jobs:
           tags: ghcr.io/collabora/whisperlive-openvino:latest
 
   publish-to-pypi:
-    needs: [run-tests, check-code-format]
+    needs: [run-tests, check-code-format, venv-install-smoke-test]
     runs-on: ubuntu-22.04
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,9 @@ setup(
         "openvino-tokenizers",
         "optimum", 
         "optimum-intel",
+        "fastapi",
+        "uvicorn",
+        "python-multipart",
     ],
     python_requires=">=3.9"
 )


### PR DESCRIPTION
Fixes #329

## Summary
- add a CI smoke-test job that builds the package and installs it into a fresh virtualenv
- verify `whisper_live` imports cleanly after the isolated install
- make the docker build jobs wait for the new packaging check

## Testing
- python -m build --sdist --wheel
- python -m venv /tmp/whisperlive-smoke-venv
- pip install --no-deps dist/*.whl
- python -c "import whisper_live"