### PR TITLE
ci: verify install in a fresh virtual environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements/server.txt --extra-index-url https://download.pytorch.org/whl/cpu
           pip install -r requirements/client.txt
+
+      - name: Verify package installs in a fresh venv
+        run: |
+          python -m venv /tmp/whisperlive-venv
+          /tmp/whisperlive-venv/bin/python -m pip install --upgrade pip
+          /tmp/whisperlive-venv/bin/pip install .
       
       - name: Run tests
         run: |


### PR DESCRIPTION
Fixes #329\n\nAdd a CI smoke step that creates a fresh virtual environment and installs the package there, so packaging and install regressions are caught earlier.