### PR TITLE
fix: add av to package requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     ),
     install_requires=[
         "PyAudio",
+        "av",
         "faster-whisper==1.2.0",
         "torch",
         "torchaudio",


### PR DESCRIPTION
## Summary

Adds the `av` package to `install_requires` so it is installed with WhisperLive.

## Testing

- `python3 setup.py check`
- `python3 setup.py egg_info` and verified `Requires-Dist: av` is present

Fixes #495