### PR TITLE
fix: relax tokenizers version constraint

### DIFF
--- a/requirements/server.txt
+++ b/requirements/server.txt
@@ -11,7 +11,7 @@ jiwer
 evaluate
 numpy<2
 openai-whisper==20250625
-tokenizers==0.20.3
+tokenizers>=0.20.3,<0.23
 transformers[torch]
 sentencepiece
 

--- a/requirements/server.txt
+++ b/requirements/server.txt
@@ -12,7 +12,7 @@ evaluate
 numpy<2
 openai-whisper==20250625
 tokenizers>=0.20.3,<0.23
-transformers[torch]
+transformers[torch]<5
 sentencepiece
 
 # openvino

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         "openai-whisper==20250625",
         "kaldialign",
         "soundfile",
+        "transformers[torch]<5",
         "tokenizers>=0.20.3,<0.23",
         "librosa",
         "numpy==1.26.4",

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "openai-whisper==20250625",
         "kaldialign",
         "soundfile",
-        "tokenizers==0.20.3",
+        "tokenizers>=0.20.3,<0.23",
         "librosa",
         "numpy==1.26.4",
         "openvino",


### PR DESCRIPTION
## Summary
Relax the tokenizers dependency from a single pinned version to a bounded range that supports both the current Transformers 4.46 stack and newer Transformers releases through 4.57.

Fixes #508

## List of files changed and why
- `setup.py` - allow `tokenizers>=0.20.3,<0.23` instead of only `0.20.3`.
- `requirements/server.txt` - keep server requirements aligned with package metadata.

## How Has This Been Tested?
- `python3 -m py_compile setup.py`
- `/tmp/whisperlive-venv/bin/python -m pip install --dry-run 'transformers==4.57.1' 'tokenizers>=0.20.3,<0.23'`\n- `/tmp/whisperlive-venv/bin/python -m pip install --dry-run 'transformers==4.46.3' 'tokenizers>=0.20.3,<0.23'`\n