### PR TITLE
Make initial_prompt accessible from the client (flat params; supersedes #283)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ client = TranscriptionClient(
   mute_audio_playback=False,                          # Only used for file input, False by Default
   enable_translation=True,
   target_language="hi",
+  initial_prompt=None,                                # Add context for the model, e.g. 'Jane Doe context'
 )
 ```
 It connects to the server running on localhost at port 9090. Using a multilingual model, language for the transcription will be automatically detected. You can also use the language option to specify the target language for the transcription, in this case, English ("en"). The translate option should be set to `True` if we want to translate from the source language to English and `False` if we want to transcribe in the source language.

--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -49,6 +49,8 @@ class Client:
         word_timestamps=False,
         max_retries=0,
         retry_delay=5,
+        initial_prompt=None,
+        vad_parameters=None,
     ):
         """
         Initializes a Client instance for audio recording and streaming to a server.
@@ -75,6 +77,8 @@ class Client:
             target_language (str, optional): Target language for translation. Defaults to 'fr'.
             translation_callback (callable, optional): A callback function to handle translation results. Default is None.
             translation_srt_file_path (str, optional): The file path to save the translated output SRT file. Default is "output_translated.srt".
+            initial_prompt (str, optional): Optional text to provide context to the model (e.g. domain vocabulary or names). Default is None.
+            vad_parameters (dict, optional): Optional voice-activity-detection parameters passed to the server backend. Default is None.
         """
         self.recording = False
         self.task = "transcribe"
@@ -103,6 +107,10 @@ class Client:
         self.translation_callback = translation_callback
         self.translation_srt_file_path = translation_srt_file_path
         self.last_translated_segment = None
+
+        self.initial_prompt = initial_prompt
+        self.vad_parameters = vad_parameters
+
         if translate:
             self.task = "translate"
         self.enable_timestamps = enable_timestamps
@@ -330,6 +338,8 @@ class Client:
                     "enable_diarization": self.enable_diarization,
                     "max_speakers": self.max_speakers,
                     "word_timestamps": self.word_timestamps,
+                    "initial_prompt": self.initial_prompt,
+                    "vad_parameters": self.vad_parameters,
                 }
             )
         )
@@ -855,6 +865,8 @@ class TranscriptionClient(TranscriptionTeeClient):
         enable_diarization=False,
         max_speakers=10,
         word_timestamps=False,
+        initial_prompt=None,
+        vad_parameters=None,
     ):
 
         self.client = Client(
@@ -882,6 +894,8 @@ class TranscriptionClient(TranscriptionTeeClient):
             enable_diarization=enable_diarization,
             max_speakers=max_speakers,
             word_timestamps=word_timestamps,
+            initial_prompt=initial_prompt,
+            vad_parameters=vad_parameters,
         )
 
         if save_output_recording and not output_recording_filename.endswith(".wav"):


### PR DESCRIPTION
## Summary

Makes `initial_prompt` (and `vad_parameters`) accessible from the client so callers can give the model context (domain vocabulary, names, etc.). This supersedes #283 with a cleaner, backward-compatible implementation.

## Why not the `options` dict from #283

#283 routes `initial_prompt` through a generic `options={...}` bag and changes the server to read `options["options"].get("initial_prompt")`. That has two problems:

- **Default-path crash.** The client defaults `options=None`, so the handshake sends `"options": None`. On the server `options["options"].get(...)` becomes `None.get(...)` → `AttributeError`, breaking the faster_whisper backend unless the caller explicitly passes an `options` dict.
- **Parallel config convention.** Every other client setting (`hotwords`, `send_last_n_segments`, `no_speech_thresh`, `target_language`, …) is a flat, named parameter sent as a flat handshake key. The `options` bag introduces a second, inconsistent channel for the same job.

## This PR instead

- Adds `initial_prompt` and `vad_parameters` as **flat client parameters**, consistent with the existing convention.
- Sends them as flat handshake keys.
- Server reads them with plain null-safe `options.get("initial_prompt")` / `options.get("vad_parameters")` — no crash path.
- README example uses the flat `initial_prompt=` form.

Net change is ~15 lines (README +1, client.py +14); the server already handled flat `options.get(...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
