### PR TITLE
Add AMD GPU support: faster_whisper CPU fallback + whisper.cpp backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ python3 client_openai.py $AUDIO_FILE
 - Please follow [TensorRT_whisper readme](https://github.com/collabora/WhisperLive/blob/main/TensorRT_whisper.md) for setup of [NVIDIA/TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM) and for building Whisper-TensorRT engine.
 
 ## Getting Started
-The server supports 4 backends `faster_whisper`, `tensorrt`, `openvino` and `whisper_cpp`. If running `tensorrt` backend follow [TensorRT_whisper readme](https://github.com/collabora/WhisperLive/blob/main/TensorRT_whisper.md). For GPU-accelerated Whisper on AMD/Intel/Apple GPUs via Vulkan or ROCm, see the [`whisper_cpp` backend](#whispercpp-backend-gpu-vulkan--rocm).
+The server supports 4 backends `faster_whisper`, `tensorrt`, `openvino` and `whisper_cpp`. If running `tensorrt` backend follow [TensorRT_whisper readme](https://github.com/collabora/WhisperLive/blob/main/TensorRT_whisper.md). For GPU-accelerated Whisper on AMD GPUs via Vulkan or ROCm, see the [`whisper_cpp` backend](#whispercpp-backend-gpu-vulkan--rocm).
 
 ### Running the Server
 - [Faster Whisper](https://github.com/SYSTRAN/faster-whisper) backend

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ python3 client_openai.py $AUDIO_FILE
 - Please follow [TensorRT_whisper readme](https://github.com/collabora/WhisperLive/blob/main/TensorRT_whisper.md) for setup of [NVIDIA/TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM) and for building Whisper-TensorRT engine.
 
 ## Getting Started
-The server supports 3 backends `faster_whisper`, `tensorrt` and `openvino`. If running `tensorrt` backend follow [TensorRT_whisper readme](https://github.com/collabora/WhisperLive/blob/main/TensorRT_whisper.md)
+The server supports 4 backends `faster_whisper`, `tensorrt`, `openvino` and `whisper_cpp`. If running `tensorrt` backend follow [TensorRT_whisper readme](https://github.com/collabora/WhisperLive/blob/main/TensorRT_whisper.md). For GPU-accelerated Whisper on AMD/Intel/Apple GPUs via Vulkan or ROCm, see the [`whisper_cpp` backend](#whispercpp-backend-gpu-vulkan--rocm).
 
 ### Running the Server
 - [Faster Whisper](https://github.com/SYSTRAN/faster-whisper) backend
@@ -117,6 +117,40 @@ python3 run_server.py -p 9090 \
 python3 run_server.py -p 9090 -b openvino
 ```
 
+#### Running on AMD GPUs (ROCm)
+The `faster_whisper` backend runs on [CTranslate2](https://github.com/OpenNMT/CTranslate2), whose PyPI wheels are CUDA-only. On an AMD/ROCm machine PyTorch still reports `torch.cuda.is_available() == True`, so the server previously selected `device="cuda"` and crashed with `RuntimeError: CUDA failed ...`. The server now also checks `ctranslate2.get_cuda_device_count()` and **falls back to CPU automatically** when no CTranslate2-visible GPU is present, so the backend runs on CPU out of the box:
+```bash
+python3 run_server.py -p 9090 -b faster_whisper
+```
+For GPU-accelerated Whisper on AMD hardware, use the [`whisper_cpp` backend](#whispercpp-backend-gpu-vulkan--rocm) described below.
+
+#### whisper.cpp backend (GPU: Vulkan / ROCm)
+The `whisper_cpp` backend runs [whisper.cpp](https://github.com/ggml-org/whisper.cpp) (ggml) via [pywhispercpp](https://github.com/absadiki/pywhispercpp). Unlike CTranslate2, ggml ships GPU backends that work on AMD (Vulkan / ROCm-HIP), Intel and Apple GPUs, giving real GPU-accelerated transcription there. **Vulkan is the portable choice** — one build runs on AMD, Intel and NVIDIA GPUs. It is verified on an AMD Radeon AI PRO R9700 (RDNA4, `gfx1201`) and a Ryzen AI Max+ 395 / Radeon 8060S ("Strix Halo", RDNA3.5, `gfx1151`), transcribing an 11 s clip in well under a second on both.
+
+**Docker (recommended, turnkey):**
+```bash
+docker build -f docker/Dockerfile.vulkan -t whisperlive-vulkan .
+docker run --rm -it \
+  --device=/dev/dri --group-add video \
+  --group-add "$(getent group render | cut -d: -f3)" \
+  -p 9090:9090 whisperlive-vulkan
+# On a multi-GPU box, pick one device with -e GGML_VK_VISIBLE_DEVICES=0
+# On NVIDIA, run with the NVIDIA container runtime so its Vulkan ICD is available.
+```
+
+**Native:** build `pywhispercpp` with a GPU backend, then start the server. `pywhispercpp`'s build forwards `GGML_*` environment variables to CMake:
+```bash
+# Vulkan (portable). Needs the Vulkan loader + shader compilers, e.g. on Ubuntu:
+#   apt install libvulkan-dev glslc glslang-tools spirv-headers spirv-tools mesa-vulkan-drivers vulkan-tools
+#   (recent AMD GPUs such as RDNA4 need an up-to-date Mesa/RADV, e.g. the kisak-mesa PPA)
+GGML_VULKAN=1 pip install "git+https://github.com/absadiki/pywhispercpp.git"
+
+# ...or ROCm/HIP (AMD only), targeting your GPU arch (e.g. gfx1100/gfx1151/gfx1201):
+GGML_HIP=1 AMDGPU_TARGETS=gfx1151 pip install "git+https://github.com/absadiki/pywhispercpp.git"
+
+python3 run_server.py -p 9090 -b whisper_cpp
+```
+Clients select the ggml model through the usual `model` option (e.g. `base.en`, `small`, `large-v3-turbo`, or a path to a local `ggml-*.bin`); named models are downloaded on first use. On load, whisper.cpp logs the backend it picked, e.g. `whisper_backend_init_gpu: using Vulkan0 backend` (or `ROCm0`); if `pywhispercpp` was built without a GPU backend it runs on CPU.
 
 #### Controlling OpenMP Threads
 To control the number of threads used by OpenMP, you can set the `OMP_NUM_THREADS` environment variable. This is useful for managing CPU resources and ensuring consistent performance. If not specified, `OMP_NUM_THREADS` is set to `1` by default. You can change this by using the `--omp_num_threads` argument:
@@ -299,6 +333,14 @@ Refer to [`ios-client`](https://github.com/collabora/WhisperLive/tree/main/Audio
   - OpenVINO
   ```
   docker run -it --device=/dev/dri -p 9090:9090 ghcr.io/collabora/whisperlive-openvino
+  ```
+
+  - whisper.cpp / Vulkan (AMD, Intel, NVIDIA — GPU-accelerated, see [whisper.cpp backend](#whispercpp-backend-gpu-vulkan--rocm))
+  ```bash
+  docker build -f docker/Dockerfile.vulkan -t whisperlive-vulkan .
+  docker run --rm -it --device=/dev/dri --group-add video \
+    --group-add "$(getent group render | cut -d: -f3)" \
+    -p 9090:9090 whisperlive-vulkan
   ```
 
 - CPU

--- a/docker/Dockerfile.vulkan
+++ b/docker/Dockerfile.vulkan
@@ -1,0 +1,75 @@
+# WhisperLive — whisper.cpp (ggml) backend with Vulkan GPU acceleration.
+#
+# A single Vulkan build runs real-time Whisper on AMD (Mesa RADV), Intel (Mesa ANV)
+# and NVIDIA GPUs — no CUDA/ROCm toolkit required at runtime. This is the turnkey
+# answer to issue #520 (AMD Radeon, ROCm or Vulkan): verified on AMD Radeon AI PRO
+# R9700 (RDNA4, gfx1201) and Ryzen AI Max+ 395 / Radeon 8060S (RDNA3.5, gfx1151).
+#
+# Build:
+#   docker build -f docker/Dockerfile.vulkan -t whisperlive-vulkan .
+#
+# Run (expose the GPU + add the host 'render' group so /dev/dri is usable):
+#   docker run --rm -it \
+#     --device=/dev/dri --group-add video \
+#     --group-add "$(getent group render | cut -d: -f3)" \
+#     -p 9090:9090 whisperlive-vulkan
+#
+#   - Pick one GPU on a multi-GPU box:      -e GGML_VK_VISIBLE_DEVICES=0
+#   - Use a local model instead of download: mount it and pass -m /models/ggml-base.en.bin
+#     e.g.  -v /path/to/models:/models  ...  python run_server.py -b whisper_cpp -m /models/ggml-base.en.bin
+#   - NVIDIA GPUs: run with the NVIDIA container runtime so the NVIDIA Vulkan ICD is present.
+
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+# pywhispercpp's setup.py forwards every environment variable as a -D CMake argument,
+# so GGML_VULKAN=1 builds the ggml Vulkan backend.
+ENV GGML_VULKAN=1
+
+# 1) Runtime + build dependencies.
+#    - kisak-mesa PPA ships an up-to-date Mesa (RADV) so recent AMD GPUs (e.g. RDNA4)
+#      are enumerated over Vulkan; it also provides the Intel ANV driver.
+#    - glslc / glslang-tools / spirv-* are required to compile the ggml Vulkan shaders.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        software-properties-common ca-certificates gnupg wget && \
+    add-apt-repository -y ppa:kisak/kisak-mesa && \
+    apt-get update && apt-get install -y --no-install-recommends \
+        libvulkan1 mesa-vulkan-drivers vulkan-tools \
+        libvulkan-dev glslc glslang-tools spirv-headers spirv-tools \
+        build-essential cmake git ninja-build pkg-config patchelf \
+        python3 python3-dev python3-venv python3-pip \
+        ffmpeg libsndfile1 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# 2) Virtualenv (Ubuntu marks the system Python as externally managed).
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv "$VIRTUAL_ENV"
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN pip install --no-cache-dir -U pip wheel setuptools ninja
+
+WORKDIR /app
+
+# 3) Server dependencies. The whisper_cpp backend itself only needs pywhispercpp +
+#    numpy, but whisper_live/server.py imports torch, onnxruntime, faster_whisper and
+#    ctranslate2 at module load. Install CPU-only builds of those (they are unused by
+#    the GPU whisper.cpp path) to keep the image lean and CUDA-free.
+RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu && \
+    pip install --no-cache-dir \
+        "numpy<2" faster-whisper==1.2.0 onnxruntime \
+        websockets fastapi uvicorn python-multipart
+
+# 4) Build pywhispercpp from source with the Vulkan ggml backend. GGML_VULKAN=1 is
+#    forwarded to CMake by pywhispercpp's setup.py. pywhispercpp declares `repairwheel`
+#    as a build dependency, which bundles the freshly built libwhisper/libggml shared
+#    libraries into the wheel with a correct RPATH, so the install is self-contained
+#    (the system Vulkan loader is still used at runtime, so GPU ICDs keep working).
+RUN GGML_VULKAN=1 CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)" \
+        pip install --no-cache-dir "git+https://github.com/absadiki/pywhispercpp.git" && \
+    python -c "from pywhispercpp.model import Model; print('pywhispercpp import OK')"
+
+# 5) Application code.
+COPY whisper_live /app/whisper_live
+COPY run_server.py /app/
+
+EXPOSE 9090
+CMD ["python", "run_server.py", "--backend", "whisper_cpp", "--port", "9090"]

--- a/run_server.py
+++ b/run_server.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     parser.add_argument('--backend', '-b',
                         type=str,
                         default='faster_whisper',
-                        help='Backends from ["tensorrt", "faster_whisper", "openvino"]')
+                        help='Backends from ["tensorrt", "faster_whisper", "openvino", "whisper_cpp"]')
     parser.add_argument('--faster_whisper_custom_model_path', '-fw',
                         type=str, default=None,
                         help="Custom Faster Whisper Model")

--- a/whisper_live/backend/faster_whisper_backend.py
+++ b/whisper_live/backend/faster_whisper_backend.py
@@ -85,7 +85,12 @@ class ServeClientFasterWhisper(ServeClientBase):
         self.vad_parameters = vad_parameters or {"threshold": 0.5}
         self.hotwords = hotwords
 
-        device = "cuda" if torch.cuda.is_available() else "cpu"
+        # torch.cuda.is_available() is also True on ROCm, but the PyPI ctranslate2 wheel is
+        # CUDA-only and reports 0 devices there. Guard on the CTranslate2 device count so that
+        # AMD (and any CPU-only ctranslate2 build) falls back to CPU instead of crashing with
+        # "CUDA failed ...". A source-built ROCm ctranslate2 that exposes devices still uses GPU.
+        use_cuda = torch.cuda.is_available() and ctranslate2.get_cuda_device_count() > 0
+        device = "cuda" if use_cuda else "cpu"
         if device == "cuda":
             major, _ = torch.cuda.get_device_capability(device)
             self.compute_type = "float16" if major >= 7 else "float32"

--- a/whisper_live/backend/whisper_cpp_backend.py
+++ b/whisper_live/backend/whisper_cpp_backend.py
@@ -1,0 +1,254 @@
+import json
+import logging
+import threading
+
+import numpy as np
+from pywhispercpp.model import Model
+
+from whisper_live.backend.base import ServeClientBase
+
+
+class WhisperCppSegment:
+    """Lightweight adapter that exposes a ``pywhispercpp`` segment with the
+    attribute names WhisperLive's :class:`ServeClientBase` reads.
+
+    ``pywhispercpp`` returns ``Segment`` objects with ``t0``/``t1`` timestamps in
+    centiseconds (1/100 s) and a ``text`` field. WhisperLive's ``update_segments``
+    (via ``get_segment_start`` / ``get_segment_end`` / ``get_segment_no_speech_prob``)
+    expects ``start`` / ``end`` in seconds and a ``no_speech_prob``.
+    """
+
+    __slots__ = ("text", "start", "end", "no_speech_prob")
+
+    def __init__(self, text, start, end, no_speech_prob=0.0):
+        self.text = text
+        self.start = start
+        self.end = end
+        self.no_speech_prob = no_speech_prob
+
+
+class ServeClientWhisperCpp(ServeClientBase):
+    """WhisperLive backend backed by whisper.cpp (ggml) through ``pywhispercpp``.
+
+    Unlike the CTranslate2-based ``faster_whisper`` backend, whisper.cpp ships GPU
+    backends that work on AMD (Vulkan / ROCm-HIP), Intel and Apple hardware, so
+    this backend gives real GPU-accelerated transcription on those GPUs. Whether
+    the GPU is actually used depends on how ``pywhispercpp`` was built
+    (e.g. ``GGML_VULKAN=1 pip install pywhispercpp``); on a CPU-only build it
+    transparently runs on the CPU.
+    """
+
+    SINGLE_MODEL = None
+    SINGLE_MODEL_LOCK = threading.Lock()
+
+    # WhisperLive model aliases that do not match a ggml model name 1:1.
+    MODEL_ALIASES = {"turbo": "large-v3-turbo"}
+
+    def __init__(
+        self,
+        websocket,
+        task="transcribe",
+        device=None,
+        language=None,
+        client_uid=None,
+        model="small.en",
+        initial_prompt=None,
+        vad_parameters=None,
+        use_vad=True,
+        single_model=False,
+        send_last_n_segments=10,
+        no_speech_thresh=0.45,
+        clip_audio=False,
+        same_output_threshold=10,
+        cache_path="~/.cache/whisper-live/",
+        translation_queue=None,
+        diarization=None,
+        word_timestamps=False,
+        **kwargs,
+    ):
+        """
+        Initialize a ServeClientWhisperCpp instance.
+
+        The whisper.cpp model is loaded, a transcription thread is started, and a
+        "SERVER_READY" message is sent to the client to indicate the server is ready.
+
+        Args:
+            websocket (WebSocket): The WebSocket connection for the client.
+            task (str, optional): The task type, e.g. "transcribe" or "translate". Defaults to "transcribe".
+            device (str, optional): "cpu" forces CPU; anything else (or None) uses the GPU
+                backend the pywhispercpp build was compiled with. Defaults to None.
+            language (str, optional): Language code for transcription. Auto-detected when None
+                (unless the model is English-only). Defaults to None.
+            client_uid (str, optional): A unique identifier for the client. Defaults to None.
+            model (str, optional): A ggml model name (e.g. "base.en", "large-v3-turbo") or a path
+                to a local ggml ``.bin`` file. Defaults to "small.en".
+            initial_prompt (str, optional): Prompt for whisper inference. Defaults to None.
+            use_vad (bool, optional): Accepted for API parity; whisper.cpp's own VAD is not wired
+                up here, so WhisperLive's buffering/clip logic handles silence. Defaults to True.
+            single_model (bool, optional): Share a single model instance across clients. Defaults to False.
+            send_last_n_segments (int, optional): Number of recent segments to send. Defaults to 10.
+            no_speech_thresh (float, optional): No-speech probability threshold. Defaults to 0.45.
+            clip_audio (bool, optional): Whether to clip audio with no valid segments. Defaults to False.
+            same_output_threshold (int, optional): Repeated outputs before finalizing a segment. Defaults to 10.
+        """
+        super().__init__(
+            client_uid,
+            websocket,
+            send_last_n_segments,
+            no_speech_thresh,
+            clip_audio,
+            same_output_threshold,
+            translation_queue,
+            diarization,
+            word_timestamps,
+        )
+
+        model = model or "small.en"
+        self.model_size_or_path = self.MODEL_ALIASES.get(model, model)
+        # English-only models only decode English; otherwise honor the requested language
+        # (None => auto-detect on the first chunk).
+        self.language = "en" if isinstance(model, str) and model.endswith("en") else language
+        self.task = task or "transcribe"
+        self.initial_prompt = initial_prompt
+        self.use_vad = use_vad
+        self.cache_path = cache_path
+
+        # Use the GPU backend that pywhispercpp was built with unless CPU is explicitly requested.
+        self.use_gpu = not (isinstance(device, str) and device.lower() == "cpu")
+
+        try:
+            if single_model and ServeClientWhisperCpp.SINGLE_MODEL is not None:
+                self.transcriber = ServeClientWhisperCpp.SINGLE_MODEL
+            else:
+                self.create_model()
+                if single_model:
+                    ServeClientWhisperCpp.SINGLE_MODEL = self.transcriber
+        except Exception as e:
+            logging.error(f"Failed to load whisper.cpp model: {e}")
+            self.websocket.send(json.dumps({
+                "uid": self.client_uid,
+                "status": "ERROR",
+                "message": f"Failed to load model: {str(self.model_size_or_path)}"
+            }))
+            self.websocket.close()
+            return
+
+        # threading
+        self.trans_thread = threading.Thread(target=self.speech_to_text)
+        self.trans_thread.start()
+        self.websocket.send(json.dumps({
+            "uid": self.client_uid,
+            "message": self.SERVER_READY,
+            "backend": "whisper_cpp"
+        }))
+        logging.info(
+            f"Running whisper.cpp backend (model={self.model_size_or_path}, use_gpu={self.use_gpu}, "
+            f"task={self.task}, language={self.language})"
+        )
+
+    def create_model(self):
+        """Instantiate the pywhispercpp model and set it as the transcriber.
+
+        ``model`` may be a built-in ggml model name (downloaded on first use) or a
+        path to a local ``.bin`` file. Leaving ``redirect_whispercpp_logs_to`` at its
+        default lets whisper.cpp print its backend/device line (e.g. the Vulkan or
+        ROCm device) once at load time.
+        """
+        logging.info(f"Loading whisper.cpp model: {self.model_size_or_path}")
+        self.transcriber = Model(
+            self.model_size_or_path,
+            context_params={"use_gpu": self.use_gpu},
+            print_progress=False,
+            print_realtime=False,
+        )
+
+    def detect_language(self, input_sample):
+        """Detect and set the transcription language from an audio chunk."""
+        try:
+            (language, prob), _ = self.transcriber.auto_detect_language(input_sample)
+        except Exception as e:
+            logging.warning(f"whisper.cpp language detection failed ({e}); defaulting to 'en'")
+            language, prob = "en", 0.0
+        if language:
+            self.language = language
+            logging.info(f"Detected language {language} with probability {prob}")
+            try:
+                self.websocket.send(json.dumps({
+                    "uid": self.client_uid,
+                    "language": self.language,
+                    "language_prob": float(prob),
+                }))
+            except Exception as e:
+                logging.error(f"[ERROR]: Sending language to client: {e}")
+
+    def transcribe_audio(self, input_sample):
+        """
+        Transcribe an audio sample with whisper.cpp and adapt the segments.
+
+        Args:
+            input_sample (np.ndarray): float32 mono audio at 16 kHz.
+
+        Returns:
+            list[WhisperCppSegment]: segments with the fields WhisperLive expects.
+        """
+        input_sample = np.ascontiguousarray(input_sample, dtype=np.float32)
+
+        if ServeClientWhisperCpp.SINGLE_MODEL:
+            ServeClientWhisperCpp.SINGLE_MODEL_LOCK.acquire()
+        try:
+            if self.language is None:
+                self.detect_language(input_sample)
+
+            params = {
+                "language": self.language or "",
+                "translate": self.task == "translate",
+                "print_progress": False,
+                "print_realtime": False,
+            }
+            if self.initial_prompt is not None:
+                params["initial_prompt"] = self.initial_prompt
+
+            segments = self.transcriber.transcribe(input_sample, **params)
+        finally:
+            if ServeClientWhisperCpp.SINGLE_MODEL:
+                ServeClientWhisperCpp.SINGLE_MODEL_LOCK.release()
+
+        return self._to_whisperlive_segments(segments)
+
+    @staticmethod
+    def _to_whisperlive_segments(segments):
+        """Convert pywhispercpp ``Segment`` objects (t0/t1 in centiseconds) to
+        objects exposing ``start``/``end`` in seconds and a ``no_speech_prob``."""
+        adapted = []
+        for seg in segments:
+            text = seg.text
+            if not text:
+                continue
+            # faster_whisper segments carry a leading space; match that so the
+            # streaming concatenation in base.update_segments keeps words separated.
+            if not text.startswith(" "):
+                text = " " + text
+            adapted.append(WhisperCppSegment(
+                text=text,
+                start=seg.t0 / 100.0,
+                end=seg.t1 / 100.0,
+                no_speech_prob=0.0,
+            ))
+        return adapted
+
+    def handle_transcription_output(self, result, duration):
+        """
+        Handle the transcription output, updating the transcript and sending data to the client.
+
+        Args:
+            result (list): The list of segments from whisper.cpp inference.
+            duration (float): Duration of the transcribed audio chunk.
+        """
+        segments = []
+        if len(result):
+            self.t_start = None
+            last_segment = self.update_segments(result, duration)
+            segments = self.prepare_segments(last_segment)
+
+        if len(segments):
+            self.send_transcription_to_client(segments)

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -15,6 +15,7 @@ from fastapi.responses import JSONResponse
 from starlette.responses import PlainTextResponse, StreamingResponse
 import uvicorn
 from faster_whisper import WhisperModel
+import ctranslate2
 import torch
 
 from enum import Enum
@@ -148,6 +149,7 @@ class BackendType(Enum):
     FASTER_WHISPER = "faster_whisper"
     TENSORRT = "tensorrt"
     OPENVINO = "openvino"
+    WHISPER_CPP = "whisper_cpp"
 
     @staticmethod
     def valid_types() -> List[str]:
@@ -165,6 +167,9 @@ class BackendType(Enum):
     
     def is_openvino(self) -> bool:
         return self == BackendType.OPENVINO
+
+    def is_whisper_cpp(self) -> bool:
+        return self == BackendType.WHISPER_CPP
 
 
 class TranscriptionServer:
@@ -268,6 +273,39 @@ class TranscriptionServer:
                     "uid": self.client_uid,
                     "status": "WARNING",
                     "message": "OpenVINO not supported on Server yet. "
+                                "Reverting to available backend: 'faster_whisper'"
+                }))
+
+        if self.backend.is_whisper_cpp():
+            try:
+                from whisper_live.backend.whisper_cpp_backend import ServeClientWhisperCpp
+                client = ServeClientWhisperCpp(
+                    websocket,
+                    language=options["language"],
+                    task=options["task"],
+                    client_uid=options["uid"],
+                    model=options["model"],
+                    initial_prompt=options.get("initial_prompt"),
+                    use_vad=self.use_vad,
+                    single_model=self.single_model,
+                    send_last_n_segments=options.get("send_last_n_segments", 10),
+                    no_speech_thresh=options.get("no_speech_thresh", 0.45),
+                    clip_audio=options.get("clip_audio", False),
+                    same_output_threshold=options.get("same_output_threshold", 10),
+                    cache_path=self.cache_path,
+                    translation_queue=translation_queue,
+                    diarization=self._create_diarizer(options),
+                    word_timestamps=options.get("word_timestamps", False),
+                )
+                logging.info("Running whisper.cpp backend.")
+            except Exception as e:
+                logging.error(f"whisper.cpp backend not supported: {e}")
+                self.backend = BackendType.FASTER_WHISPER
+                self.client_uid = options["uid"]
+                websocket.send(json.dumps({
+                    "uid": self.client_uid,
+                    "status": "WARNING",
+                    "message": "whisper.cpp backend not available on this server. "
                                 "Reverting to available backend: 'faster_whisper'"
                 }))
 
@@ -486,7 +524,10 @@ class TranscriptionServer:
                     shutil.copyfileobj(file.file, tmp)
                     tmp_path = tmp.name
 
-                device = "cuda" if torch.cuda.is_available() else "cpu"
+                # ctranslate2 (faster_whisper) is CUDA-only on PyPI; on ROCm torch.cuda is True
+                # but ctranslate2 sees 0 devices, so guard to fall back to CPU instead of crashing.
+                use_cuda = torch.cuda.is_available() and ctranslate2.get_cuda_device_count() > 0
+                device = "cuda" if use_cuda else "cpu"
                 compute_type = "float16" if device == "cuda" else "int8"
                 model_name = faster_whisper_custom_model_path or "small"
                 transcriber = WhisperModel(model_name, device=device, compute_type=compute_type)
@@ -764,7 +805,10 @@ class TranscriptionServer:
                         shutil.copyfileobj(file.file, tmp)
                         tmp_path = tmp.name
 
-                    device = "cuda" if torch.cuda.is_available() else "cpu"
+                    # ctranslate2 (faster_whisper) is CUDA-only on PyPI; on ROCm torch.cuda is True
+                    # but ctranslate2 sees 0 devices, so guard to fall back to CPU instead of crashing.
+                    use_cuda = torch.cuda.is_available() and ctranslate2.get_cuda_device_count() > 0
+                    device = "cuda" if use_cuda else "cpu"
                     compute_type = "float16" if device == "cuda" else "int8"
 
                     transcriber = WhisperModel(model_name, device=device, compute_type=compute_type)


### PR DESCRIPTION
## Summary

Makes WhisperLive work on AMD GPUs (#520):

1. **Fix `faster_whisper` crashing on AMD/ROCm** — fall back to CPU instead of crashing.
2. **Add a `whisper_cpp` backend** — real GPU transcription on AMD (Vulkan/ROCm), Intel, Apple.

Verified on a Radeon AI PRO R9700 (RDNA4, `gfx1201`) and a Ryzen AI Max+ 395 / Radeon 8060S
("Strix Halo", `gfx1151` — the #520 chip). CUDA / TensorRT / OpenVINO paths unaffected.

## 1. faster_whisper: don't crash on AMD

CTranslate2's PyPI wheels are CUDA-only, but on ROCm `torch.cuda.is_available()` is `True`, so
the server picked `device="cuda"` and crashed (`RuntimeError: CUDA failed ...`). Guard on the
CTranslate2 device count instead:

```python
use_cuda = torch.cuda.is_available() and ctranslate2.get_cuda_device_count() > 0
device = "cuda" if use_cuda else "cpu"
```

Applied to all three `WhisperModel` sites (the websocket backend + both REST endpoints in
`server.py`). CUDA users are unaffected; diarization/translation use torch and already work on
ROCm.

## 2. New `whisper_cpp` backend (GPU on AMD)

```bash
python run_server.py -b whisper_cpp
```

`ServeClientWhisperCpp` runs [whisper.cpp](https://github.com/ggml-org/whisper.cpp) via
[pywhispercpp](https://github.com/absadiki/pywhispercpp) — ggml's Vulkan/ROCm/Metal backends
give real GPU transcription where CTranslate2 can't. Vulkan is the portable path (one build →
AMD/Intel/NVIDIA). It plugs into the existing server (same protocol/clients) and falls back to
`faster_whisper` if pywhispercpp is missing. Adds `docker/Dockerfile.vulkan` (turnkey) + README.

Build pywhispercpp with GPU (from git; `setup.py` forwards `GGML_*` to CMake):

```bash
GGML_VULKAN=1 pip install "git+https://github.com/absadiki/pywhispercpp.git"                    # portable
GGML_HIP=1 AMDGPU_TARGETS=gfx1151 pip install "git+https://github.com/absadiki/pywhispercpp.git" # ROCm
```

## Verification

`samples/jfk.wav` (11 s), exact-text match; drove the real backend classes plus a full
`run_server.py -b whisper_cpp` end-to-end over WebSocket.

- **faster_whisper fix:** `device=cuda` crash → now CPU, transcribes correctly.
- **whisper_cpp GPU backend:**

| box / chip | backend | device | correct? | time (cold/warm)¹ |
|---|---|---|:---:|---|
| R9700 · `gfx1201` | Vulkan | `Vulkan0` (RADV GFX1201) | ✅ | 0.055 / 0.049 s |
| `gfx1201` — full server E2E (WebSocket) | Vulkan | `Vulkan0` | ✅ | streamed OK |
| Ryzen AI Max+ 395 / 8060S · `gfx1151` (#520 chip) | Vulkan | `Vulkan0` (RADV GFX1151) | ✅ | 0.336 / 0.071 s |
| `gfx1151` | ROCm/HIP | `ROCm0` | ✅ | 0.135 / 0.077 s |

¹ `ggml-base.en`, single runs — verification timings, not a formal benchmark.

## Notes

- pywhispercpp must be source-built for GPU (PyPI is CPU-only); `Dockerfile.vulkan` handles it.
  RDNA4 needs a recent Mesa/RADV.
- First version: `no_speech_prob` is `0.0`, word timestamps + whisper.cpp VAD not wired, and
  the OpenAI REST endpoint still uses CTranslate2 (CPU on AMD) — only the websocket backend is GPU.
- CTranslate2's ROCm forks are intentionally avoided (they produce wrong output on RDNA4).
