### PR TITLE
Add AMD ROCm GPU support for faster_whisper backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ python3 run_server.py -p 9090 \
 python3 run_server.py -p 9090 -b openvino
 ```
 
+### Setting up AMD ROCm for faster_whisper backend
+- Please follow [ROCm_whisper readme](https://github.com/collabora/WhisperLive/blob/main/ROCm_whisper.md) for setup of AMD ROCm GPU support with the CTranslate2 ROCm wheel.
+
 
 #### Controlling OpenMP Threads
 To control the number of threads used by OpenMP, you can set the `OMP_NUM_THREADS` environment variable. This is useful for managing CPU resources and ensuring consistent performance. If not specified, `OMP_NUM_THREADS` is set to `1` by default. You can change this by using the `--omp_num_threads` argument:
@@ -299,6 +302,15 @@ Refer to [`ios-client`](https://github.com/collabora/WhisperLive/tree/main/Audio
   - OpenVINO
   ```
   docker run -it --device=/dev/dri -p 9090:9090 ghcr.io/collabora/whisperlive-openvino
+  ```
+
+  - AMD ROCm (faster-whisper on AMD GPU via CTranslate2 ROCm wheel)
+  ```bash
+  docker build -f docker/Dockerfile.rocm -t whisperlive-rocm .
+  docker run --rm -it --device=/dev/kfd --device=/dev/dri \
+      --group-add "$(getent group video | cut -d: -f3)" \
+      --group-add "$(getent group render | cut -d: -f3)" \
+      -p 9090:9090 whisperlive-rocm
   ```
 
 - CPU

--- a/ROCm_whisper.md
+++ b/ROCm_whisper.md
@@ -1,0 +1,66 @@
+# WhisperLive-ROCm
+Run WhisperLive's `faster_whisper` backend on AMD GPUs using the official [CTranslate2 ROCm wheel](https://github.com/OpenNMT/CTranslate2/releases). Tested on Radeon AI PRO R9700 (gfx1201/RDNA4) and Ryzen AI Max+ 395 / Radeon 8060S (gfx1151/Strix Halo).
+
+## Docker Installation (recommended)
+- Install [docker](https://docs.docker.com/engine/install/)
+
+- Build and run the WhisperLive ROCm image:
+```bash
+docker build -f docker/Dockerfile.rocm -t whisperlive-rocm .
+docker run --rm -it \
+    --device=/dev/kfd --device=/dev/dri \
+    --group-add "$(getent group video | cut -d: -f3)" \
+    --group-add "$(getent group render | cut -d: -f3)" \
+    -p 9090:9090 whisperlive-rocm
+```
+
+## Native Installation
+
+### Prerequisites
+- AMD GPU with ROCm support (see [supported GPUs](https://rocm.docs.amd.com/en/latest/compatibility/compatibility-matrix.html))
+- ROCm 7.2+ installed ([installation guide](https://rocm.docs.amd.com/en/latest/deploy/linux/quick_start.html))
+- User in `video` and `render` groups (`sudo usermod -aG video,render $USER`, re-login)
+- Python 3.12
+
+### Verify ROCm is working
+```bash
+rocminfo | grep -E 'Name:|gfx'
+# Should show your GPU, e.g. "Name: gfx1151" or "Name: gfx1201"
+```
+
+### Install CTranslate2 ROCm wheel
+The default `pip install ctranslate2` installs a CUDA-only wheel. Replace it with the official ROCm wheel from the [CTranslate2 releases page](https://github.com/OpenNMT/CTranslate2/releases):
+
+```bash
+# Download the ROCm wheels archive (v4.8.0)
+curl -LO https://github.com/OpenNMT/CTranslate2/releases/download/v4.8.0/rocm-python-wheels-Linux.zip
+
+# Extract the Python 3.12 wheel
+unzip -j rocm-python-wheels-Linux.zip 'temp-linux/ctranslate2-*-cp312-*manylinux*x86_64.whl'
+
+# Install (replaces any existing ctranslate2)
+pip install ctranslate2-*-cp312-*.whl
+```
+
+### Install WhisperLive server requirements
+```bash
+pip install -r requirements/server.txt
+```
+
+### Verify GPU is visible to CTranslate2
+```bash
+python -c "import ctranslate2; print('devices:', ctranslate2.get_cuda_device_count())"
+```
+Expected output: `devices: 1` (CTranslate2 uses the name "cuda" even on ROCm).
+
+If you see `devices: 0`, check:
+- Your user is in `video` and `render` groups (re-login after adding)
+- `/dev/kfd` exists and is accessible
+- The ROCm wheel was installed (not the default PyPI CUDA-only one)
+
+## Run WhisperLive Server with ROCm
+```bash
+python3 run_server.py --port 9090 --backend faster_whisper
+```
+
+The server automatically uses the AMD GPU when the CTranslate2 ROCm wheel is installed. For multi-GPU systems, use `HIP_VISIBLE_DEVICES=N` to select a specific GPU.

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -1,0 +1,44 @@
+# docker/Dockerfile.rocm
+#
+# WhisperLive faster_whisper backend on AMD ROCm GPUs.
+# Uses the official CTranslate2 ROCm wheel (ships kernels for gfx803 through
+# gfx1201 including Strix Halo gfx1151 and RDNA4 gfx1200/1201).
+#
+# Build:
+#   docker build -f docker/Dockerfile.rocm -t whisperlive-rocm .
+#
+# Run (expose the WebSocket port; add --enable_rest --rest_port 8000 -p 8000:8000 for REST):
+#   docker run --rm -it \
+#       --device=/dev/kfd --device=/dev/dri \
+#       --group-add "$(getent group video | cut -d: -f3)" \
+#       --group-add "$(getent group render | cut -d: -f3)" \
+#       -p 9090:9090 whisperlive-rocm
+
+FROM rocm/pytorch:rocm7.2.4_ubuntu24.04_py3.12_pytorch_release_2.10.0
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG CT2_WHEEL_URL=https://github.com/OpenNMT/CTranslate2/releases/download/v4.8.0/rocm-python-wheels-Linux.zip
+
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends curl unzip portaudio19-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install the CTranslate2 ROCm wheel (official release artifact).
+# This replaces any CUDA-only ctranslate2 and enables GPU on AMD.
+RUN curl -sL "${CT2_WHEEL_URL}" -o /tmp/ct2-rocm.zip && \
+    unzip -j /tmp/ct2-rocm.zip 'temp-linux/ctranslate2-*-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl' -d /tmp && \
+    pip install --no-cache-dir --force-reinstall /tmp/ctranslate2-*-cp312-*.whl && \
+    rm -f /tmp/ct2-rocm.zip /tmp/ctranslate2-*.whl
+
+# Install server requirements
+COPY requirements/server.txt /app/
+RUN pip install --no-cache-dir -r server.txt && rm server.txt
+
+COPY whisper_live /app/whisper_live
+COPY run_server.py /app
+
+EXPOSE 9090
+
+CMD ["python", "run_server.py", "--port", "9090", "--backend", "faster_whisper"]


### PR DESCRIPTION
Add ROCm_whisper.md (Docker + native install guide) and docker/Dockerfile.rocm based on rocm/pytorch:rocm7.2.4 (PyTorch 2.10.0) that installs the official CTranslate2 v4.8.0 ROCm wheel. The default faster_whisper backend runs on AMD GPUs out of the box with no code changes.

Tested on Radeon AI PRO R9700 (gfx1201) and Ryzen AI Max+ 395 / Radeon 8060S (gfx1151) with ROCm 7.2.4.

Addresses #520.