### PR TITLE
fix: allow NumPy 2 for pyannote audio

### DIFF
--- a/requirements/server.txt
+++ b/requirements/server.txt
@@ -9,7 +9,7 @@ scipy
 av
 jiwer
 evaluate
-numpy<2
+numpy>=1.26.4,<2.5
 openai-whisper==20250625
 tokenizers==0.20.3
 transformers[torch]

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         "soundfile",
         "tokenizers==0.20.3",
         "librosa",
-        "numpy==1.26.4",
+        "numpy>=1.26.4,<2.5",
         "openvino",
         "openvino-genai",
         "openvino-tokenizers",


### PR DESCRIPTION
Fixes #521

Also addresses the dependency conflict reported in #519.

## Summary

- Relax the NumPy pin in both package metadata and server requirements so current pyannote.audio releases can resolve.
- Keep NumPy below 2.5 because the current numba release requires that upper bound.

## Testing

- `python -m unittest tests.test_diarization tests.test_utils tests.test_base_backend` (85 tests passed)
- `flake8 setup.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- Built both sdist and wheel; verified wheel metadata contains `numpy<2.5,>=1.26.4`
- Installed a resolved Python 3.12 stack with NumPy 2.4.6, numba 0.66.0, and pyannote.audio 4.0.7
