### PR TITLE
fix: propagate WebSocket send errors

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -149,6 +149,13 @@ class TestSendingAudioPacket(BaseTestCase):
         self.client.send_packet_to_server(self.mock_audio_packet)
         self.client.client_socket.send.assert_called_with(self.mock_audio_packet, websocket.ABNF.OPCODE_BINARY)
 
+    def test_send_packet_propagates_websocket_error(self):
+        error = websocket.WebSocketConnectionClosedException("connection closed")
+        self.client.client_socket.send.side_effect = error
+
+        with self.assertRaises(websocket.WebSocketConnectionClosedException):
+            self.client.send_packet_to_server(self.mock_audio_packet)
+
 class TestTee(BaseTestCase):
     @patch('whisper_live.client.websocket.WebSocketApp')
     @patch('whisper_live.client.pyaudio.PyAudio')

--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -352,11 +352,11 @@ class Client:
         Args:
             message (bytes): The audio data packet in bytes to be sent to the server.
 
+        Raises:
+            Exception: If the WebSocket fails to send the packet.
+
         """
-        try:
-            self.client_socket.send(message, websocket.ABNF.OPCODE_BINARY)
-        except Exception as e:
-            print(e)
+        self.client_socket.send(message, websocket.ABNF.OPCODE_BINARY)
 
     def close_websocket(self):
         """


### PR DESCRIPTION
Fixes #525

## Summary

- let WebSocket send exceptions propagate to callers
- add regression coverage for a closed-connection send failure

## Tests

- `python -m unittest discover -s tests -p 'test_client.py'` (15 passed)
- `python -m pytest tests/test_streaming_client.py -q` (19 passed)
- `git ls-files -z '*.py' | xargs -0 flake8 --count --select=E9,F63,F7,F82 --show-source --statistics` (0 errors)
