### PR TITLE
feat: return completed transcript from client

### DIFF
--- a/tests/test_client_extended.py
+++ b/tests/test_client_extended.py
@@ -3,7 +3,7 @@ import time
 import unittest
 from unittest.mock import patch, MagicMock, PropertyMock
 
-from whisper_live.client import Client, TranscriptionTeeClient
+from whisper_live.client import Client, TranscriptionClient, TranscriptionTeeClient
 
 
 class TestClientStatusMessages(unittest.TestCase):
@@ -180,6 +180,25 @@ class TestClientTranscriptionCallback(unittest.TestCase):
         })
         # should not raise
         self.client.on_message(MagicMock(), msg)
+
+
+class TestTranscriptionClientResult(unittest.TestCase):
+    @patch.object(TranscriptionTeeClient, "__call__")
+    def test_call_returns_completed_transcript(self, mock_call):
+        client = object.__new__(TranscriptionClient)
+        client.client = MagicMock(
+            transcript=[
+                {"text": " Hello "},
+                {"text": "world"},
+            ]
+        )
+
+        result = client(audio="sample.wav")
+
+        self.assertEqual(result, "Hello world")
+        mock_call.assert_called_once_with(
+            audio="sample.wav", rtsp_url=None, hls_url=None, save_file=None
+        )
 
 
 class TestClientSrtWriting(unittest.TestCase):

--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -834,7 +834,7 @@ class TranscriptionClient(TranscriptionTeeClient):
         To create a TranscriptionClient and start transcription on microphone audio:
         ```python
         transcription_client = TranscriptionClient(host="localhost", port=9090)
-        transcription_client()
+        transcript = transcription_client()
         ```
     """
     def __init__(
@@ -912,6 +912,11 @@ class TranscriptionClient(TranscriptionTeeClient):
             output_recording_filename=output_recording_filename,
             mute_audio_playback=mute_audio_playback
         )
+
+    def __call__(self, audio=None, rtsp_url=None, hls_url=None, save_file=None):
+        """Run transcription and return the completed transcript as text."""
+        super().__call__(audio=audio, rtsp_url=rtsp_url, hls_url=hls_url, save_file=save_file)
+        return " ".join(segment["text"].strip() for segment in self.client.transcript)
 
 
 PcmFormat = Literal["float32", "int16"]


### PR DESCRIPTION
## Summary

- return the completed transcript text from `TranscriptionClient.__call__`
- preserve the existing console, callback, and SRT behavior
- add focused regression coverage for the returned text

Fixes #220

## Testing

- `python -m unittest tests.test_client_extended tests.test_client` (38 passed)
- `flake8 whisper_live/client.py tests/test_client_extended.py --count --select=E9,F63,F7,F82 --show-source --statistics` (passed)
- `git diff --check` (passed)
