### PR TITLE
fix: honor display_segments when printing the transcript

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -143,6 +143,46 @@ class TestPrintTranscript(unittest.TestCase):
         self.assertGreater(len(output_lines), 1)
         self.assertTrue(output_lines[1].startswith(" " * len("[00:00 -> 00:05] ")))
 
+    @patch("whisper_live.utils.shutil.get_terminal_size")
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_print_transcript_honors_max_lines(self, mock_stdout, mock_terminal_size):
+        mock_terminal_size.return_value = os.terminal_size((80, 20))
+
+        print_transcript([f"segment {i} of the running transcript. " for i in range(10)], max_lines=4)
+
+        output_lines = [line for line in mock_stdout.getvalue().splitlines() if line.strip()]
+        self.assertEqual(len(output_lines), 4)
+        self.assertNotIn("segment 0", "".join(output_lines))
+
+    @patch("whisper_live.utils.shutil.get_terminal_size")
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_print_transcript_defaults_to_three_lines(self, mock_stdout, mock_terminal_size):
+        mock_terminal_size.return_value = os.terminal_size((80, 20))
+
+        print_transcript([f"segment {i} of the running transcript. " for i in range(10)])
+
+        output_lines = [line for line in mock_stdout.getvalue().splitlines() if line.strip()]
+        self.assertEqual(len(output_lines), 3)
+
+
+class TestTranscriptDisplay(BaseTestCase):
+    @patch("whisper_live.utils.shutil.get_terminal_size")
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_display_segments_controls_printed_lines(self, mock_stdout, mock_terminal_size):
+        mock_terminal_size.return_value = os.terminal_size((80, 20))
+        self.client.display_segments = 8
+        self.client.transcript = [
+            {"start": str(i), "end": str(i + 1), "text": f"segment {i} of the running transcript. "}
+            for i in range(8)
+        ]
+
+        self.client.process_segments([{"start": "8", "end": "9", "text": "tail", "completed": False}])
+
+        output = mock_stdout.getvalue()
+        output_lines = [line for line in output.splitlines() if line.strip()]
+        self.assertGreater(len(output_lines), 3)
+        self.assertIn("segment 0", output)
+
 
 class TestSendingAudioPacket(BaseTestCase):
     def test_send_packet(self):

--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -78,6 +78,7 @@ class Client:
             target_language (str, optional): Target language for translation. Defaults to 'fr'.
             translation_callback (callable, optional): A callback function to handle translation results. Default is None.
             translation_srt_file_path (str, optional): The file path to save the translated output SRT file. Default is "output_translated.srt".
+            display_segments (int, optional): Number of recent transcript segments to display, and the maximum lines printed. Defaults to 4.
             initial_prompt (str, optional): Optional text to provide context to the model (e.g. domain vocabulary or names). Default is None.
             vad_parameters (dict, optional): Optional voice-activity-detection parameters passed to the server backend. Default is None.
         """
@@ -221,25 +222,27 @@ class Client:
                         "text": self.last_segment["text"]
                     })
                 utils.clear_screen()
-                utils.print_transcript(original_text_with_timestamps, timestamps=True)
+                utils.print_transcript(original_text_with_timestamps, timestamps=True, max_lines=self.display_segments)
 
                 if self.enable_translation:
                     print(f"\n\nTRANSLATION to {self.target_language}:")
                     utils.print_transcript([
                         {"start": seg["start"], "end": seg["end"], "text": seg["text"]}
                         for seg in self.translated_transcript[-self.display_segments:]
-                    ], timestamps=True)
+                    ], timestamps=True, max_lines=self.display_segments)
 
             else:
                 original_text = [seg["text"] for seg in self.transcript[-self.display_segments:]]
                 if self.last_segment is not None and self.last_segment["text"] not in original_text:
                     original_text.append(self.last_segment["text"])
                 utils.clear_screen()
-                utils.print_transcript(original_text)
+                utils.print_transcript(original_text, max_lines=self.display_segments)
 
                 if self.enable_translation:
                     print(f"\n\nTRANSLATION to {self.target_language}:")
-                    utils.print_transcript([seg["text"] for seg in self.translated_transcript[-self.display_segments:]], translated=True)
+                    utils.print_transcript(
+                        [seg["text"] for seg in self.translated_transcript[-self.display_segments:]],
+                        translated=True, max_lines=self.display_segments)
 
 
     def on_message(self, ws, message):
@@ -826,6 +829,7 @@ class TranscriptionClient(TranscriptionTeeClient):
         target_language (str, optional): Target language for translation. Defaults to 'fr'.
         translation_callback (callable, optional): A callback function to handle translation results. Default is None.
         translation_srt_file_path (str, optional): The file path to save the translated output SRT file. Default is "output_translated.srt".
+        display_segments (int, optional): Number of recent transcript segments to display, and the maximum lines printed. Defaults to 4.
 
     Attributes:
         client (Client): An instance of the underlying Client class responsible for handling the WebSocket connection.

--- a/whisper_live/utils.py
+++ b/whisper_live/utils.py
@@ -12,8 +12,8 @@ def clear_screen():
     print("\033[H\033[2J", end="", flush=True)
 
 
-def print_transcript(text, translated=False, timestamps=False):
-    """Prints formatted transcript text in a subtitle-like block."""
+def print_transcript(text, translated=False, timestamps=False, max_lines=3):
+    """Prints the last `max_lines` wrapped lines of transcript text in a subtitle-like block."""
     terminal_width = shutil.get_terminal_size((80, 20)).columns
     wrap_width = max(10, min(80, terminal_width - 8))
 
@@ -31,7 +31,7 @@ def print_transcript(text, translated=False, timestamps=False):
         transcript = " ".join(text) if translated else "".join(text)
         lines = wrapper.wrap(text=transcript)
 
-    for line in lines[-3:]:
+    for line in lines[-max_lines:]:
         print(line.center(terminal_width))
 
 


### PR DESCRIPTION
`print_transcript` truncated output to the last 3 wrapped lines regardless of the caller's `display_segments`, so the setting had no visible effect.

Fixes #526

## Problem

Setting `display_segments` (or `--n_display_segments`) to any value leaves the terminal showing roughly three lines. With translation enabled the transcript and translation blocks are capped independently, giving 3 + 3.

## Cause

`whisper_live/utils.py:34` hardcoded `lines[-3:]`. The client slices `self.transcript[-self.display_segments:]` correctly; `print_transcript` then discards everything past the last three wrapped lines.

The two halves landed independently: `display_segments` in 067573a (Mar 8), the line cap in 8c0caf1 (Jun 21).

## Fix

Make the cap a `max_lines` argument defaulting to 3, so the subtitle-style output is unchanged for every existing caller, and pass `display_segments` from the client's four display paths (timestamped and plain, transcript and translation).

Also adds the missing `display_segments` entry to the `Client` and `TranscriptionClient` docstrings — part of the report was that neither documented it.

## Testing

`python -m unittest discover -s tests` — no new failures.

Three tests added. `test_display_segments_controls_printed_lines` fails on `main` with `AssertionError: 3 not greater than 3`; `test_print_transcript_honors_max_lines` covers an explicit cap, and `test_print_transcript_defaults_to_three_lines` guards the unchanged default.
