### PR TITLE
fix: correct WebSocket authentication callback

### DIFF
--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -3,10 +3,12 @@ import time
 import threading
 import collections
 import unittest
+from http import HTTPStatus
 from unittest import mock
 from unittest.mock import MagicMock, patch
+from websockets.http11 import Request
 
-from whisper_live.server import TranscriptionServer, BackendType, ClientManager
+from whisper_live.server import TranscriptionServer, BackendType, ClientManager, _websocket_auth
 
 
 class TestClientManagerAddRemove(unittest.TestCase):
@@ -659,15 +661,13 @@ class TestWebSocketAuth(unittest.TestCase):
     def _make_auth_handler(self, api_key):
         """Build the same auth function the server creates."""
         def _ws_auth(path, request_headers):
-            auth = request_headers.get("Authorization", "")
-            token_param = None
-            if "?" in path:
-                from urllib.parse import urlparse, parse_qs
-                parsed = urlparse(path)
-                token_param = parse_qs(parsed.query).get("token", [None])[0]
-            if auth == f"Bearer {api_key}" or token_param == api_key:
-                return None
-            return (401, [("Content-Type", "text/plain")], b"Unauthorized\n")
+            connection = MagicMock()
+            connection.respond.return_value = (401, [], b"Unauthorized\n")
+            request = Request(path, request_headers)
+            result = _websocket_auth(api_key, connection, request)
+            if result is not None:
+                connection.respond.assert_called_once_with(HTTPStatus.UNAUTHORIZED, "Unauthorized\n")
+            return result
         return _ws_auth
 
     def test_valid_bearer_token(self):

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -8,6 +8,7 @@ import functools
 import logging
 import shutil
 import tempfile
+from http import HTTPStatus
 from typing import Optional, List
 from fastapi import FastAPI, UploadFile, Form, Request, File
 from fastapi.middleware.cors import CORSMiddleware
@@ -27,6 +28,19 @@ from whisper_live.vad import VoiceActivityDetector
 from whisper_live.backend.base import ServeClientBase
 
 logging.basicConfig(level=logging.INFO)
+
+
+def _websocket_auth(api_key, connection, request):
+    auth = request.headers.get("Authorization", "")
+    token_param = None
+    if "?" in request.path:
+        from urllib.parse import urlparse, parse_qs
+        parsed = urlparse(request.path)
+        token_param = parse_qs(parsed.query).get("token", [None])[0]
+    if auth == f"Bearer {api_key}" or token_param == api_key:
+        return None
+    return connection.respond(HTTPStatus.UNAUTHORIZED, "Unauthorized\n")
+
 
 class ClientManager:
     def __init__(self, max_clients=4, max_connection_time=600):
@@ -855,18 +869,7 @@ class TranscriptionServer:
         # Original WebSocket server (always supported)
         extra_ws_kwargs = {}
         if api_key:
-            def _ws_auth(path, request_headers):
-                auth = request_headers.get("Authorization", "")
-                token_param = None
-                # Check query string for token parameter
-                if "?" in path:
-                    from urllib.parse import urlparse, parse_qs
-                    parsed = urlparse(path)
-                    token_param = parse_qs(parsed.query).get("token", [None])[0]
-                if auth == f"Bearer {api_key}" or token_param == api_key:
-                    return None  # Allow connection
-                return (401, [("Content-Type", "text/plain")], b"Unauthorized\n")
-            extra_ws_kwargs["process_request"] = _ws_auth
+            extra_ws_kwargs["process_request"] = functools.partial(_websocket_auth, api_key)
 
         with serve(
             functools.partial(

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -10,6 +10,7 @@ import shutil
 import tempfile
 from http import HTTPStatus
 from typing import Optional, List
+from urllib.parse import parse_qs, urlparse
 from fastapi import FastAPI, UploadFile, Form, Request, File
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -34,7 +35,6 @@ def _websocket_auth(api_key, connection, request):
     auth = request.headers.get("Authorization", "")
     token_param = None
     if "?" in request.path:
-        from urllib.parse import urlparse, parse_qs
         parsed = urlparse(request.path)
         token_param = parse_qs(parsed.query).get("token", [None])[0]
     if auth == f"Bearer {api_key}" or token_param == api_key:


### PR DESCRIPTION
Fixes #532

## Summary

- update the authentication callback to consume `ServerConnection` and `Request`
- return the sync server's response object for unauthorized handshakes
- exercise the production callback with real `Request` objects for header and query authentication

## Testing

- `python -m unittest tests.test_server_extended` (54 tests passed)
- `python -m flake8 tests/test_server_extended.py whisper_live/server.py --count --select=E9,F63,F7,F82 --show-source --statistics` (0 errors)
