### PR TITLE
fix: retain only final word audio for reprocessing

### DIFF
--- a/tests/test_base_backend.py
+++ b/tests/test_base_backend.py
@@ -626,6 +626,22 @@ class TestWordTimestamps(unittest.TestCase):
         self.assertIsNotNone(last)
         self.assertIn("words", last)
 
+    def test_update_segments_retains_only_last_word_audio(self):
+        client = self._make_client(word_timestamps=True)
+        words = [
+            self._make_word(" hello", 0.0, 0.5, 0.9),
+            self._make_word(" world", 0.6, 1.0, 0.85),
+        ]
+        segment = self._make_segment(" hello world", 0.0, 1.0, words=words)
+
+        last = client.update_segments([segment], 2.0)
+
+        self.assertEqual(client.transcript[-1]["text"], " hello")
+        self.assertAlmostEqual(client.timestamp_offset, 0.6)
+        self.assertEqual(last["text"], " world")
+        self.assertEqual(last["start"], "0.600")
+        self.assertEqual(len(last["words"]), 1)
+
     def test_update_segments_no_words_when_disabled(self):
         client = self._make_client(word_timestamps=False)
         words1 = [self._make_word("hello", 0.0, 0.5, 0.9)]

--- a/whisper_live/backend/base.py
+++ b/whisper_live/backend/base.py
@@ -1,8 +1,10 @@
 import json
 import logging
+import queue
 import threading
 import time
-import queue
+from types import SimpleNamespace
+
 import numpy as np
 
 from whisper_live import metrics as wl_metrics
@@ -380,6 +382,27 @@ class ServeClientBase(object):
             for w in words
         ]
 
+    def _split_last_segment_at_final_word(self, segments):
+        """Keep only the final word of the incomplete segment for reprocessing."""
+        last = segments[-1]
+        last_words = getattr(last, "words", None)
+        if not self.word_timestamps or not last_words or len(last_words) <= 1:
+            return segments
+
+        trailing_word = last_words[-1]
+        no_speech_prob = self.get_segment_no_speech_prob(last)
+        completed_prefix = SimpleNamespace(
+            start=self.get_segment_start(last), end=trailing_word.start,
+            text="".join(word.word for word in last_words[:-1]),
+            words=last_words[:-1], no_speech_prob=no_speech_prob,
+        )
+        incomplete_word = SimpleNamespace(
+            start=trailing_word.start, end=trailing_word.end,
+            text=trailing_word.word, words=[trailing_word],
+            no_speech_prob=no_speech_prob,
+        )
+        return [*segments[:-1], completed_prefix, incomplete_word]
+
     def update_segments(self, segments, duration):
         """
         Processes the segments from Whisper and updates the transcript.
@@ -395,6 +418,7 @@ class ServeClientBase(object):
         offset = None
         self.current_out = ''
         last_segment = None
+        segments = self._split_last_segment_at_final_word(segments)
 
         # Process complete segments only if there are more than one
         # and if the last segment's no_speech_prob is below the threshold.


### PR DESCRIPTION
Fixes #330

## Summary

- split a timestamped incomplete segment at its final word
- commit the stable prefix and advance the audio offset to the final word's start
- preserve the existing behavior when word timestamps are disabled or unavailable

## Testing

- `python -m unittest discover -s tests` (246 passed, 14 skipped)
- `flake8 . --exclude=.venv --count --select=E9,F63,F7,F82 --show-source --statistics` (0 findings)
