### PR TITLE
batch inference fixes and transcript_finalizer hook

### DIFF
--- a/tests/test_base_backend.py
+++ b/tests/test_base_backend.py
@@ -640,5 +640,49 @@ class TestWordTimestamps(unittest.TestCase):
         self.assertNotIn("words", last)
 
 
+class TestFinalize(unittest.TestCase):
+    def _client(self):
+        client = ConcreteServeClient(client_uid="uid", websocket=MagicMock())
+        client.transcript = [{"start": 0.0, "end": 1.0, "text": "hi"}]
+        return client
+
+    def test_no_finalizer_sends_nothing(self):
+        client = self._client()
+        client.finalize()
+        client.websocket.send.assert_not_called()
+
+    def test_finalizer_payload_is_sent_with_uid(self):
+        client = self._client()
+        client.transcript_finalizer = lambda transcript: {"paragraphs": ["hi"]}
+        client.finalize()
+        client.websocket.send.assert_called_once()
+        sent = json.loads(client.websocket.send.call_args[0][0])
+        self.assertEqual(sent["uid"], "uid")
+        self.assertEqual(sent["paragraphs"], ["hi"])
+
+    def test_finalizer_receives_transcript(self):
+        seen = {}
+        client = self._client()
+
+        def finalizer(transcript):
+            seen["t"] = transcript
+            return None
+
+        client.transcript_finalizer = finalizer
+        client.finalize()
+        self.assertEqual(seen["t"], client.transcript)
+        client.websocket.send.assert_not_called()  # None -> nothing sent
+
+    def test_finalizer_exception_is_swallowed(self):
+        client = self._client()
+
+        def boom(transcript):
+            raise RuntimeError("nope")
+
+        client.transcript_finalizer = boom
+        client.finalize()  # must not raise
+        client.websocket.send.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_base_backend.py
+++ b/tests/test_base_backend.py
@@ -6,6 +6,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+from websockets.exceptions import ConnectionClosed
 
 from whisper_live.backend.base import ServeClientBase
 
@@ -686,3 +687,30 @@ class TestFinalize(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestSendTranscriptionToClient(unittest.TestCase):
+    """A client that hangs up mid-send is a normal disconnect, not an error."""
+
+    def setUp(self):
+        self.ws = MagicMock()
+        self.client = ConcreteServeClient(client_uid="test", websocket=self.ws)
+        self.segments = [{"start": "0.0", "end": "1.0", "text": "hello", "completed": True}]
+
+    def test_segments_reach_the_client(self):
+        self.client.send_transcription_to_client(self.segments)
+        sent = json.loads(self.ws.send.call_args[0][0])
+        self.assertEqual(sent["uid"], "test")
+        self.assertEqual(sent["segments"], self.segments)
+
+    def test_a_client_that_hung_up_is_not_logged_as_an_error(self):
+        self.ws.send.side_effect = ConnectionClosed(None, None)
+        with self.assertLogs(level="INFO") as captured:
+            self.client.send_transcription_to_client(self.segments)
+        self.assertFalse(any(line.startswith("ERROR") for line in captured.output))
+
+    def test_a_real_send_failure_is_still_an_error(self):
+        self.ws.send.side_effect = RuntimeError("socket exploded")
+        with self.assertLogs(level="ERROR") as captured:
+            self.client.send_transcription_to_client(self.segments)
+        self.assertTrue(any("socket exploded" in line for line in captured.output))

--- a/tests/test_batch_inference.py
+++ b/tests/test_batch_inference.py
@@ -203,6 +203,40 @@ class TestBatchInferenceWorker(unittest.TestCase):
         split_calls = self.mock_transcriber._split_segments_by_timestamps.call_args_list
         self.assertTrue(all(call.kwargs["tokens"] == [] for call in split_calls))
 
+    @mock.patch('whisper_live.batch_inference.get_suppressed_tokens', return_value=[-1])
+    @mock.patch('whisper_live.batch_inference.Tokenizer')
+    def test_hotwords_reach_both_paths(self, mock_tokenizer_cls, mock_suppress):
+        self._mock_multi_path(mock_tokenizer_cls, n_items=2)
+        self.mock_transcriber.transcribe.return_value = ([MagicMock()], MagicMock())
+
+        batched = [
+            BatchRequest(audio=self._make_audio(), language="en", use_vad=False, hotwords="aavaaz")
+            for _ in range(2)
+        ]
+        single = BatchRequest(audio=self._make_audio(31.0), language="en", hotwords="aavaaz")
+        self._run_batch(batched + [single])
+
+        for call in self.mock_transcriber.get_prompt.call_args_list:
+            self.assertEqual(call.kwargs["hotwords"], "aavaaz")
+        self.assertEqual(self.mock_transcriber.transcribe.call_args.kwargs["hotwords"], "aavaaz")
+
+    @mock.patch('whisper_live.batch_inference.get_suppressed_tokens', return_value=[-1])
+    @mock.patch('whisper_live.batch_inference.Tokenizer')
+    def test_word_timestamps_take_single_path(self, mock_tokenizer_cls, mock_suppress):
+        self._mock_multi_path(mock_tokenizer_cls, n_items=2)
+        self.mock_transcriber.transcribe.return_value = ([MagicMock()], MagicMock())
+
+        batched = [
+            BatchRequest(audio=self._make_audio(), language="en", use_vad=False)
+            for _ in range(2)
+        ]
+        with_words = BatchRequest(audio=self._make_audio(), language="en", word_timestamps=True)
+        self._run_batch(batched + [with_words])
+
+        self.mock_transcriber.transcribe.assert_called_once()
+        self.assertTrue(self.mock_transcriber.transcribe.call_args.kwargs["word_timestamps"])
+        self.assertEqual(self.mock_transcriber.model.generate.call_args.args[0].shape[0], 2)
+
     def test_abandoned_request_skipped(self):
         """A request whose session stopped waiting must not reach the model."""
         self.mock_transcriber.transcribe.return_value = ([MagicMock()], MagicMock())

--- a/tests/test_batch_inference.py
+++ b/tests/test_batch_inference.py
@@ -118,6 +118,7 @@ class TestBatchInferenceWorker(unittest.TestCase):
     @mock.patch('whisper_live.batch_inference.get_suppressed_tokens', return_value=[-1])
     @mock.patch('whisper_live.batch_inference.Tokenizer')
     def test_fallback_items_are_counted(self, mock_tokenizer_cls, mock_suppress):
+        self.worker.temperature_fallback = True
         self._mock_multi_path(mock_tokenizer_cls, 2, score=-3.0)
         with mock.patch("whisper_live.batch_inference.wl_metrics.track_batch_fallback") as track:
             self._run_batch([

--- a/tests/test_batch_inference.py
+++ b/tests/test_batch_inference.py
@@ -86,6 +86,36 @@ class TestBatchInferenceWorker(unittest.TestCase):
 
     @mock.patch('whisper_live.batch_inference.get_suppressed_tokens', return_value=[-1])
     @mock.patch('whisper_live.batch_inference.Tokenizer')
+    def test_beam_size_reaches_generate(self, mock_tokenizer_cls, mock_suppress):
+        self.worker.beam_size = 1
+        self._mock_multi_path(mock_tokenizer_cls, 2)
+        self._run_batch([
+            BatchRequest(audio=self._make_audio(), language="en", use_vad=False)
+            for _ in range(2)
+        ])
+        self.assertEqual(self.mock_transcriber.model.generate.call_args.kwargs["beam_size"], 1)
+
+    def test_beam_size_reaches_single_path(self):
+        self.worker.beam_size = 1
+        self.mock_transcriber.transcribe.return_value = ([], MagicMock())
+        req = BatchRequest(audio=self._make_audio(), language="en", use_vad=False)
+        self._run_batch([req])
+        self.assertEqual(self.mock_transcriber.transcribe.call_args.kwargs["beam_size"], 1)
+
+    @mock.patch('whisper_live.batch_inference.get_suppressed_tokens', return_value=[-1])
+    @mock.patch('whisper_live.batch_inference.Tokenizer')
+    def test_fallback_items_are_counted(self, mock_tokenizer_cls, mock_suppress):
+        self._mock_multi_path(mock_tokenizer_cls, 2, score=-3.0)
+        with mock.patch("whisper_live.batch_inference.wl_metrics.track_batch_fallback") as track:
+            self._run_batch([
+                BatchRequest(audio=self._make_audio(), language="en", use_vad=False)
+                for _ in range(2)
+            ])
+        track.assert_called()
+        self.assertEqual(track.call_args_list[0].args[0], 2)
+
+    @mock.patch('whisper_live.batch_inference.get_suppressed_tokens', return_value=[-1])
+    @mock.patch('whisper_live.batch_inference.Tokenizer')
     def test_multiple_requests_batched(self, mock_tokenizer_cls, mock_suppress):
         """Multiple concurrent requests should go through the batched GPU path."""
         # Mock tokenizer

--- a/tests/test_batch_inference.py
+++ b/tests/test_batch_inference.py
@@ -261,6 +261,37 @@ class TestBatchInferenceWorker(unittest.TestCase):
         mock_vad.assert_not_called()
         self.mock_transcriber.encode.assert_called()
 
+    def test_queue_wait_ema_drives_overloaded(self):
+        """A backlogged queue makes the worker report overloaded, an idle one clears it."""
+        self.worker.stop()
+        self.mock_transcriber.transcribe.return_value = ([MagicMock()], MagicMock())
+        max_queue_wait_s = 1.0
+        backlog_s = 100.0
+        worker = BatchInferenceWorker(
+            transcriber=self.mock_transcriber,
+            max_batch_size=1,
+            batch_window_ms=0,
+            max_queue_wait_s=max_queue_wait_s,
+        )
+        self.assertFalse(worker.overloaded())
+
+        lagging = BatchRequest(audio=self._make_audio(), language="en", use_vad=False)
+        lagging.submitted_at = time.monotonic() - backlog_s
+        worker._queue.put(lagging)
+        worker.start()
+        try:
+            lagging.future.wait(timeout=5)
+            self.assertGreater(worker.queue_wait_s, max_queue_wait_s)
+            self.assertTrue(worker.overloaded())
+
+            deadline = time.monotonic() + 5
+            while worker.queue_wait_s != 0.0 and time.monotonic() < deadline:
+                time.sleep(0.05)
+            self.assertEqual(worker.queue_wait_s, 0.0)
+            self.assertFalse(worker.overloaded())
+        finally:
+            worker.stop()
+
     def test_abandoned_request_skipped(self):
         """A request whose session stopped waiting must not reach the model."""
         self.mock_transcriber.transcribe.return_value = ([MagicMock()], MagicMock())

--- a/tests/test_batch_inference.py
+++ b/tests/test_batch_inference.py
@@ -237,6 +237,30 @@ class TestBatchInferenceWorker(unittest.TestCase):
         self.assertTrue(self.mock_transcriber.transcribe.call_args.kwargs["word_timestamps"])
         self.assertEqual(self.mock_transcriber.model.generate.call_args.args[0].shape[0], 2)
 
+    @mock.patch('whisper_live.batch_inference.get_speech_timestamps')
+    @mock.patch('whisper_live.batch_inference.get_suppressed_tokens', return_value=[-1])
+    @mock.patch('whisper_live.batch_inference.Tokenizer')
+    def test_prepared_request_skips_worker_preprocessing(self, mock_tokenizer_cls, mock_suppress, mock_vad):
+        """Features computed in the session thread must not be recomputed."""
+        self._mock_multi_path(mock_tokenizer_cls, n_items=2)
+
+        requests = [
+            BatchRequest(
+                audio=self._make_audio(),
+                language="en",
+                use_vad=True,
+                features=np.zeros((80, 3000), dtype=np.float32),
+                speech_chunks=None,
+                speech_duration=1.0,
+            )
+            for _ in range(2)
+        ]
+        self._run_batch(requests)
+
+        self.mock_transcriber.feature_extractor.assert_not_called()
+        mock_vad.assert_not_called()
+        self.mock_transcriber.encode.assert_called()
+
     def test_abandoned_request_skipped(self):
         """A request whose session stopped waiting must not reach the model."""
         self.mock_transcriber.transcribe.return_value = ([MagicMock()], MagicMock())

--- a/tests/test_batch_inference.py
+++ b/tests/test_batch_inference.py
@@ -40,6 +40,21 @@ class TestBatchInferenceWorker(unittest.TestCase):
         self.assertEqual(req.info, fake_info)
         self.mock_transcriber.transcribe.assert_called_once()
 
+    def test_long_audio_routed_to_single_path(self):
+        """Audio longer than 30s must not be truncated by the batched encode."""
+        self.mock_transcriber.feature_extractor.sampling_rate = 16000
+        self.mock_transcriber.transcribe.return_value = ([MagicMock()], MagicMock())
+
+        long1 = BatchRequest(audio=self._make_audio(31.0), language="en", use_vad=False)
+        long2 = BatchRequest(audio=self._make_audio(45.0), language="en", use_vad=False)
+        self.worker._process_batch([long1, long2])
+
+        # both long items go through the windowed transcribe() path, not encode()
+        self.assertEqual(self.mock_transcriber.transcribe.call_count, 2)
+        self.mock_transcriber.encode.assert_not_called()
+        self.assertTrue(long1.future.is_set())
+        self.assertTrue(long2.future.is_set())
+
     @mock.patch('whisper_live.batch_inference.get_suppressed_tokens', return_value=[-1])
     @mock.patch('whisper_live.batch_inference.Tokenizer')
     def test_multiple_requests_batched(self, mock_tokenizer_cls, mock_suppress):

--- a/tests/test_batch_inference.py
+++ b/tests/test_batch_inference.py
@@ -134,6 +134,19 @@ class TestBatchInferenceWorker(unittest.TestCase):
         self.assertIsNone(req2.error)
         self.assertIsNotNone(req2.result)
 
+    def test_abandoned_request_skipped(self):
+        """A request whose session stopped waiting must not reach the model."""
+        self.mock_transcriber.transcribe.return_value = ([MagicMock()], MagicMock())
+        abandoned = BatchRequest(audio=self._make_audio(), language="en", abandoned=True)
+        live = BatchRequest(audio=self._make_audio(), language="en")
+        self.worker.submit(abandoned)
+        self.worker.submit(live)
+        live.future.wait(timeout=5)
+
+        self.assertTrue(live.future.is_set())
+        self.assertFalse(abandoned.future.is_set())
+        self.mock_transcriber.transcribe.assert_called_once()
+
     def test_worker_stop(self):
         """Worker thread should exit cleanly when stop() is called."""
         self.assertTrue(self.worker._thread.is_alive())

--- a/tests/test_batch_inference.py
+++ b/tests/test_batch_inference.py
@@ -104,6 +104,19 @@ class TestBatchInferenceWorker(unittest.TestCase):
 
     @mock.patch('whisper_live.batch_inference.get_suppressed_tokens', return_value=[-1])
     @mock.patch('whisper_live.batch_inference.Tokenizer')
+    def test_fallback_off_decodes_once(self, mock_tokenizer_cls, mock_suppress):
+        self.worker.temperature_fallback = False
+        self._mock_multi_path(mock_tokenizer_cls, 2, score=-3.0)
+        with mock.patch("whisper_live.batch_inference.wl_metrics.track_batch_fallback") as track:
+            self._run_batch([
+                BatchRequest(audio=self._make_audio(), language="en", use_vad=False)
+                for _ in range(2)
+            ])
+        track.assert_not_called()
+        self.assertEqual(self.mock_transcriber.model.generate.call_count, 1)
+
+    @mock.patch('whisper_live.batch_inference.get_suppressed_tokens', return_value=[-1])
+    @mock.patch('whisper_live.batch_inference.Tokenizer')
     def test_fallback_items_are_counted(self, mock_tokenizer_cls, mock_suppress):
         self._mock_multi_path(mock_tokenizer_cls, 2, score=-3.0)
         with mock.patch("whisper_live.batch_inference.wl_metrics.track_batch_fallback") as track:

--- a/tests/test_batch_inference.py
+++ b/tests/test_batch_inference.py
@@ -24,6 +24,35 @@ class TestBatchInferenceWorker(unittest.TestCase):
     def _make_audio(self, duration_s=1.0):
         return np.random.randn(int(16000 * duration_s)).astype(np.float32)
 
+    def _mock_multi_path(self, mock_tokenizer_cls, n_items, no_speech_prob=0.1, score=-1.0):
+        mock_tok = MagicMock()
+        mock_tok.decode.return_value = "hello world"
+        mock_tokenizer_cls.return_value = mock_tok
+        self.mock_transcriber.feature_extractor.return_value = np.zeros((80, 3000), dtype=np.float32)
+        self.mock_transcriber.feature_extractor.sampling_rate = 16000
+        self.mock_transcriber.encode.return_value = np.zeros((n_items, 1500, 512), dtype=np.float32)
+        gen_result = MagicMock()
+        gen_result.sequences_ids = [[50257, 50362, 1234, 50256]]
+        gen_result.scores = [np.float32(score)]
+        gen_result.no_speech_prob = no_speech_prob
+        self.mock_transcriber.model.generate.return_value = [gen_result] * n_items
+        self.mock_transcriber.model.is_multilingual = False
+        self.mock_transcriber.max_length = 448
+        self.mock_transcriber.frames_per_second = 50
+        self.mock_transcriber.get_prompt.return_value = [50258]
+        self.mock_transcriber._split_segments_by_timestamps.return_value = (
+            [{"start": 0.0, "end": 1.0, "tokens": [1234], "seek": 0}],
+            None,
+            None,
+        )
+
+    def _run_batch(self, requests):
+        for req in requests:
+            self.worker.submit(req)
+        for req in requests:
+            req.future.wait(timeout=5)
+            self.assertIsNone(req.error)
+
     def test_single_request_uses_transcribe(self):
         """Single request should fall back to transcriber.transcribe()."""
         fake_segment = MagicMock()
@@ -133,6 +162,28 @@ class TestBatchInferenceWorker(unittest.TestCase):
 
         self.assertIsNone(req2.error)
         self.assertIsNotNone(req2.result)
+
+    @mock.patch('whisper_live.batch_inference.collect_chunks')
+    @mock.patch('whisper_live.batch_inference.get_speech_timestamps')
+    @mock.patch('whisper_live.batch_inference.get_suppressed_tokens', return_value=[-1])
+    @mock.patch('whisper_live.batch_inference.Tokenizer')
+    def test_vad_timestamps_restored(self, mock_tokenizer_cls, mock_suppress, mock_vad, mock_collect):
+        """Segment times must refer to the original audio, not the VAD-collapsed audio."""
+        self._mock_multi_path(mock_tokenizer_cls, n_items=2)
+        mock_vad.return_value = [{"start": 16000, "end": 32000}]
+        mock_collect.side_effect = lambda audio, chunks: ([audio[16000:32000]], None)
+
+        requests = [
+            BatchRequest(audio=self._make_audio(2.0), language="en", use_vad=True)
+            for _ in range(2)
+        ]
+        self._run_batch(requests)
+
+        for req in requests:
+            self.assertEqual(req.result[0].start, 1.0)
+            self.assertEqual(req.result[0].end, 2.0)
+            self.assertEqual(req.info.duration, 2.0)
+            self.assertEqual(req.info.duration_after_vad, 1.0)
 
     def test_abandoned_request_skipped(self):
         """A request whose session stopped waiting must not reach the model."""

--- a/tests/test_batch_inference.py
+++ b/tests/test_batch_inference.py
@@ -185,6 +185,24 @@ class TestBatchInferenceWorker(unittest.TestCase):
             self.assertEqual(req.info.duration, 2.0)
             self.assertEqual(req.info.duration_after_vad, 1.0)
 
+    @mock.patch('whisper_live.batch_inference.get_suppressed_tokens', return_value=[-1])
+    @mock.patch('whisper_live.batch_inference.Tokenizer')
+    def test_silence_yields_no_segments(self, mock_tokenizer_cls, mock_suppress):
+        """High no_speech_prob with low logprob is silence, so no text is emitted."""
+        self._mock_multi_path(mock_tokenizer_cls, n_items=2, no_speech_prob=0.9, score=-2.0)
+        self.mock_transcriber._split_segments_by_timestamps.return_value = ([], None, None)
+
+        requests = [
+            BatchRequest(audio=self._make_audio(), language="en", use_vad=False)
+            for _ in range(2)
+        ]
+        self._run_batch(requests)
+
+        for req in requests:
+            self.assertEqual(req.result, [])
+        split_calls = self.mock_transcriber._split_segments_by_timestamps.call_args_list
+        self.assertTrue(all(call.kwargs["tokens"] == [] for call in split_calls))
+
     def test_abandoned_request_skipped(self):
         """A request whose session stopped waiting must not reach the model."""
         self.mock_transcriber.transcribe.return_value = ([MagicMock()], MagicMock())

--- a/tests/test_batch_timeout.py
+++ b/tests/test_batch_timeout.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest import mock
+
+import numpy as np
+
+from whisper_live.backend.faster_whisper_backend import ServeClientFasterWhisper
+
+
+class NeverAnsweringWorker:
+    def __init__(self):
+        self.submitted = []
+
+    def submit(self, request):
+        self.submitted.append(request)
+
+
+class TestBatchWaitTimeout(unittest.TestCase):
+    def setUp(self):
+        self.client = ServeClientFasterWhisper.__new__(ServeClientFasterWhisper)
+        self.client.language = "en"
+        self.client.task = "transcribe"
+        self.client.initial_prompt = None
+        self.client.use_vad = False
+        self.client.vad_parameters = None
+        self.client.word_timestamps = False
+        self.client.client_uid = "uid"
+        self.worker = NeverAnsweringWorker()
+
+    def test_timeout_raises_and_marks_request_abandoned(self):
+        with (
+            mock.patch.object(ServeClientFasterWhisper, "BATCH_WORKER", self.worker),
+            mock.patch.object(ServeClientFasterWhisper, "BATCH_WAIT_TIMEOUT_SECONDS", 0.01),
+        ):
+            with self.assertRaises(TimeoutError):
+                self.client.transcribe_audio(np.zeros(16000, dtype=np.float32))
+
+        self.assertEqual(len(self.worker.submitted), 1)
+        self.assertTrue(self.worker.submitted[0].abandoned)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_batch_timeout.py
+++ b/tests/test_batch_timeout.py
@@ -16,6 +16,24 @@ class NeverAnsweringWorker:
         self.submitted.append(request)
 
 
+class CountingFeatureExtractor:
+    sampling_rate = 16000
+    mel_bins = 80
+    frames = 10
+
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, audio):
+        self.calls += 1
+        return np.zeros((self.mel_bins, self.frames), dtype=np.float32)
+
+
+class FakeTranscriber:
+    def __init__(self):
+        self.feature_extractor = CountingFeatureExtractor()
+
+
 class TestBatchWaitTimeout(unittest.TestCase):
     def setUp(self):
         self.client = ServeClientFasterWhisper.__new__(ServeClientFasterWhisper)
@@ -27,6 +45,7 @@ class TestBatchWaitTimeout(unittest.TestCase):
         self.client.word_timestamps = False
         self.client.hotwords = None
         self.client.client_uid = "uid"
+        self.client.transcriber = FakeTranscriber()
         self.worker = NeverAnsweringWorker()
 
     def test_timeout_raises_and_marks_request_abandoned(self):
@@ -39,6 +58,52 @@ class TestBatchWaitTimeout(unittest.TestCase):
 
         self.assertEqual(len(self.worker.submitted), 1)
         self.assertTrue(self.worker.submitted[0].abandoned)
+
+
+class TestSessionThreadPreprocessing(unittest.TestCase):
+    SECONDS_OF_AUDIO = 1.0
+    PADDED_FRAMES = 3000
+
+    def setUp(self):
+        self.client = ServeClientFasterWhisper.__new__(ServeClientFasterWhisper)
+        self.client.language = "en"
+        self.client.task = "transcribe"
+        self.client.initial_prompt = None
+        self.client.use_vad = False
+        self.client.vad_parameters = None
+        self.client.word_timestamps = False
+        self.client.hotwords = None
+        self.client.client_uid = "uid"
+        self.client.transcriber = FakeTranscriber()
+        self.worker = NeverAnsweringWorker()
+
+    def submit_one_chunk(self):
+        samples = int(CountingFeatureExtractor.sampling_rate * self.SECONDS_OF_AUDIO)
+        with (
+            mock.patch.object(ServeClientFasterWhisper, "BATCH_WORKER", self.worker),
+            mock.patch.object(ServeClientFasterWhisper, "BATCH_WAIT_TIMEOUT_SECONDS", 0.01),
+        ):
+            with self.assertRaises(TimeoutError):
+                self.client.transcribe_audio(np.zeros(samples, dtype=np.float32))
+        return self.worker.submitted[0]
+
+    def test_features_prepared_before_submit(self):
+        request = self.submit_one_chunk()
+
+        self.assertEqual(
+            request.features.shape,
+            (CountingFeatureExtractor.mel_bins, self.PADDED_FRAMES),
+        )
+        self.assertEqual(request.speech_duration, self.SECONDS_OF_AUDIO)
+        self.assertEqual(self.client.transcriber.feature_extractor.calls, 1)
+
+    def test_word_timestamps_request_left_unprepared(self):
+        self.client.word_timestamps = True
+        request = self.submit_one_chunk()
+
+        self.assertIsNone(request.features)
+        self.assertIsNone(request.speech_duration)
+        self.assertEqual(self.client.transcriber.feature_extractor.calls, 0)
 
 
 class TimingOutClient(ServeClientBase):

--- a/tests/test_batch_timeout.py
+++ b/tests/test_batch_timeout.py
@@ -1,8 +1,10 @@
+import threading
 import unittest
 from unittest import mock
 
 import numpy as np
 
+from whisper_live.backend.base import ServeClientBase
 from whisper_live.backend.faster_whisper_backend import ServeClientFasterWhisper
 
 
@@ -37,6 +39,53 @@ class TestBatchWaitTimeout(unittest.TestCase):
 
         self.assertEqual(len(self.worker.submitted), 1)
         self.assertTrue(self.worker.submitted[0].abandoned)
+
+
+class TimingOutClient(ServeClientBase):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.language = "en"
+        self.calls = 0
+
+    def transcribe_audio(self, input_sample):
+        self.calls += 1
+        self.exit = True
+        raise TimeoutError("late")
+
+    def handle_transcription_output(self, result, duration):
+        raise AssertionError("no output expected")
+
+
+class TestTimeoutDropsChunk(unittest.TestCase):
+    def test_speech_to_text_advances_offset_past_timed_out_audio(self):
+        client = TimingOutClient(client_uid="uid", websocket=mock.MagicMock())
+        client.frames_np = np.zeros(5 * ServeClientBase.RATE, dtype=np.float32)
+
+        client.speech_to_text()
+
+        self.assertEqual(client.calls, 1)
+        self.assertAlmostEqual(client.timestamp_offset, 5.0)
+
+
+class TestBatchChunkCap(unittest.TestCase):
+    def setUp(self):
+        self.client = ServeClientFasterWhisper.__new__(ServeClientFasterWhisper)
+        self.client.lock = threading.Lock()
+        self.client.frames_offset = 0.0
+        self.client.timestamp_offset = 0.0
+        self.client.frames_np = np.zeros(40 * ServeClientFasterWhisper.RATE, dtype=np.float32)
+
+    def test_batch_mode_caps_chunk_at_30s(self):
+        with mock.patch.object(ServeClientFasterWhisper, "BATCH_WORKER", object()):
+            audio, duration = self.client.get_audio_chunk_for_processing()
+        self.assertEqual(duration, 30.0)
+        self.assertEqual(audio.shape[0], 30 * ServeClientFasterWhisper.RATE)
+
+    def test_non_batch_mode_returns_whole_chunk(self):
+        with mock.patch.object(ServeClientFasterWhisper, "BATCH_WORKER", None):
+            audio, duration = self.client.get_audio_chunk_for_processing()
+        self.assertEqual(duration, 40.0)
+        self.assertEqual(audio.shape[0], 40 * ServeClientFasterWhisper.RATE)
 
 
 if __name__ == "__main__":

--- a/tests/test_batch_timeout.py
+++ b/tests/test_batch_timeout.py
@@ -23,6 +23,7 @@ class TestBatchWaitTimeout(unittest.TestCase):
         self.client.use_vad = False
         self.client.vad_parameters = None
         self.client.word_timestamps = False
+        self.client.hotwords = None
         self.client.client_uid = "uid"
         self.worker = NeverAnsweringWorker()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,4 +1,6 @@
+import socket
 import subprocess
+import sys
 import time
 import json
 import unittest
@@ -77,8 +79,19 @@ class TestServerInferenceAccuracy(unittest.TestCase):
         cls.mock_pyaudio = cls.mock_pyaudio_patch.start()
         cls.mock_pyaudio.return_value.open.return_value = mock.MagicMock()
         
-        cls.server_process = subprocess.Popen(["python", "run_server.py"])
-        time.sleep(2)
+        cls.server_process = subprocess.Popen([sys.executable, "run_server.py"])
+        cls.wait_for_server()
+
+    @staticmethod
+    def wait_for_server(host="localhost", port=9090, timeout=120):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                with socket.create_connection((host, port), timeout=1):
+                    return
+            except OSError:
+                time.sleep(0.2)
+        raise RuntimeError(f"server did not listen on {host}:{port} within {timeout}s")
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -323,6 +323,33 @@ class TestTranscriptionServerHandleNewConnection(unittest.TestCase):
         result = self.server.handle_new_connection(mock_ws, None, None, False)
         self.assertFalse(result)
 
+    @mock.patch("websockets.WebSocketCommonProtocol")
+    def test_overloaded_batch_worker_returns_false(self, mock_ws):
+        from whisper_live.backend.faster_whisper_backend import ServeClientFasterWhisper
+
+        mock_ws.recv.return_value = json.dumps({
+            "uid": "test",
+            "language": "en",
+            "task": "transcribe",
+            "model": "tiny.en",
+        })
+        queue_wait_s = 120.0
+        worker = MagicMock()
+        worker.overloaded.return_value = True
+        worker.queue_wait_s = queue_wait_s
+
+        with (
+            mock.patch.object(ServeClientFasterWhisper, "BATCH_WORKER", worker),
+            mock.patch("whisper_live.server.wl_metrics.track_connection_rejected") as track_rejected,
+        ):
+            result = self.server.handle_new_connection(mock_ws, None, None, False)
+
+        self.assertFalse(result)
+        track_rejected.assert_called_once_with(reason="overloaded")
+        sent = json.loads(mock_ws.send.call_args.args[0])
+        self.assertEqual(sent["status"], "WAIT")
+        self.assertEqual(sent["message"], queue_wait_s / TranscriptionServer.SECONDS_PER_MINUTE)
+
 
 class TestTranscriptionServerCleanup(unittest.TestCase):
     def setUp(self):

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -351,6 +351,35 @@ class TestTranscriptionServerHandleNewConnection(unittest.TestCase):
         self.assertEqual(sent["message"], queue_wait_s / TranscriptionServer.SECONDS_PER_MINUTE)
 
 
+    @mock.patch("websockets.WebSocketCommonProtocol")
+    def test_rate_limited_admission_returns_false(self, mock_ws):
+        from whisper_live.backend.faster_whisper_backend import ServeClientFasterWhisper
+        from whisper_live.server import AdmissionRateLimiter
+
+        mock_ws.recv.return_value = json.dumps({
+            "uid": "test",
+            "language": "en",
+            "task": "transcribe",
+            "model": "tiny.en",
+        })
+        worker = MagicMock()
+        worker.overloaded.return_value = False
+        worker.queue_wait_s = 0.0
+        self.server.admission_limiter = AdmissionRateLimiter(per_second=1.0)
+        self.assertTrue(self.server.admission_limiter.allow())
+
+        with (
+            mock.patch.object(ServeClientFasterWhisper, "BATCH_WORKER", worker),
+            mock.patch("whisper_live.server.wl_metrics.track_connection_rejected") as track_rejected,
+        ):
+            result = self.server.handle_new_connection(mock_ws, None, None, False)
+
+        self.assertFalse(result)
+        track_rejected.assert_called_once_with(reason="rate_limited")
+        sent = json.loads(mock_ws.send.call_args.args[0])
+        self.assertEqual(sent["status"], "WAIT")
+
+
 class TestTranscriptionServerCleanup(unittest.TestCase):
     def setUp(self):
         self.server = TranscriptionServer()
@@ -725,3 +754,18 @@ class TestWebSocketAuth(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestAdmissionRateLimiter(unittest.TestCase):
+    def test_bucket_empties_then_refills(self):
+        from whisper_live.server import AdmissionRateLimiter
+
+        clock = [100.0]
+        with mock.patch("whisper_live.server.time.monotonic", side_effect=lambda: clock[0]):
+            limiter = AdmissionRateLimiter(per_second=2.0)
+            self.assertTrue(limiter.allow())
+            self.assertTrue(limiter.allow())
+            self.assertFalse(limiter.allow())
+            clock[0] += 0.5
+            self.assertTrue(limiter.allow())
+            self.assertFalse(limiter.allow())

--- a/whisper_live/backend/base.py
+++ b/whisper_live/backend/base.py
@@ -4,6 +4,7 @@ import threading
 import time
 import queue
 import numpy as np
+from websockets.exceptions import ConnectionClosed
 
 from whisper_live import metrics as wl_metrics
 
@@ -319,6 +320,10 @@ class ServeClientBase(object):
             )
             for seg in segments:
                 wl_metrics.track_segment_emitted(completed=seg.get("completed", False))
+        except ConnectionClosed:
+            # the client hung up while this batch was on its way out, which is
+            # what a normal disconnect looks like from here
+            logging.info("Client gone before the last segments were sent")
         except Exception as e:
             logging.error(f"[ERROR]: Sending data to client: {e}")
 

--- a/whisper_live/backend/base.py
+++ b/whisper_live/backend/base.py
@@ -81,6 +81,13 @@ class ServeClientBase(object):
         # WhisperLive's core code.
         self.segment_post_processor = None
 
+        # Optional end-of-stream callable. If set, called once when the audio
+        # stream ends (while the socket is still open) with the accumulated
+        # transcript (list of segment dicts). May return a JSON-serializable
+        # dict, which is sent to the client as a final message. Lets external
+        # projects emit cross-segment results (e.g. paragraph grouping).
+        self.transcript_finalizer = None
+
         # threading
         self.lock = threading.Lock()
         self.frames_ready = threading.Event()
@@ -305,6 +312,28 @@ class ServeClientBase(object):
                 wl_metrics.track_segment_emitted(completed=seg.get("completed", False))
         except Exception as e:
             logging.error(f"[ERROR]: Sending data to client: {e}")
+
+    def finalize(self):
+        """
+        Run the optional end-of-stream finalizer and send its result, if any.
+
+        Called once when the audio stream ends and the socket is still open. If
+        ``transcript_finalizer`` is set, it receives the accumulated transcript and
+        may return a dict that is sent to the client (merged with the client uid).
+        """
+        if self.transcript_finalizer is None:
+            return
+        try:
+            payload = self.transcript_finalizer(self.transcript)
+        except Exception as e:
+            logging.error(f"[ERROR]: transcript_finalizer failed: {e}")
+            return
+        if not payload:
+            return
+        try:
+            self.websocket.send(json.dumps({"uid": self.client_uid, **payload}))
+        except Exception as e:
+            logging.error(f"[ERROR]: Sending finalizer result to client: {e}")
 
     def disconnect(self):
         """

--- a/whisper_live/backend/base.py
+++ b/whisper_live/backend/base.py
@@ -22,6 +22,9 @@ class ServeClientBase(object):
     CLIP_TAIL_DURATION_S = 5
     """Duration in seconds of audio to keep after clipping."""
     FIRST_FRAME_WAIT_TIMEOUT_S = 0.1
+    AUDIO_WAIT_TIMEOUT_S = 0.1
+    VOICE_WAIT_TIMEOUT_S = 0.25
+    ERROR_BACKOFF_S = 1.0
     """Interval in seconds for re-checking exit while waiting for the first audio frame."""
 
     client_uid: str
@@ -123,7 +126,8 @@ class ServeClientBase(object):
 
             input_bytes, duration = self.get_audio_chunk_for_processing()
             if duration < 1.0:
-                time.sleep(0.1)     # wait for audio chunks to arrive
+                self.frames_ready.clear()
+                self.frames_ready.wait(timeout=self.AUDIO_WAIT_TIMEOUT_S)
                 continue
             try:
                 input_sample = input_bytes.copy()
@@ -132,16 +136,21 @@ class ServeClientBase(object):
 
                 if result is None or self.language is None:
                     self.timestamp_offset += duration
-                    time.sleep(0.25)    # wait for voice activity, result is None when no voice activity
+                    self.frames_ready.clear()
+                    self.frames_ready.wait(timeout=self.VOICE_WAIT_TIMEOUT_S)
                     continue
                 wl_metrics.track_transcription_latency(time.time() - t0)
                 wl_metrics.track_audio_processed(duration)
                 self.handle_transcription_output(result, duration)
 
+            except TimeoutError as e:
+                logging.error(f"[ERROR]: Dropping {duration:.1f}s of audio: {e}")
+                wl_metrics.track_error("transcription")
+                self.timestamp_offset += duration
             except Exception as e:
                 logging.error(f"[ERROR]: Failed to transcribe audio chunk: {e}")
                 wl_metrics.track_error("transcription")
-                time.sleep(0.01)
+                time.sleep(self.ERROR_BACKOFF_S)
 
     def transcribe_audio(self):
         raise NotImplementedError

--- a/whisper_live/backend/faster_whisper_backend.py
+++ b/whisper_live/backend/faster_whisper_backend.py
@@ -16,6 +16,9 @@ class ServeClientFasterWhisper(ServeClientBase):
     SINGLE_MODEL_LOCK = threading.Lock()
     BATCH_WAIT_TIMEOUT_SECONDS = 30
     BATCH_WORKER = None
+    BATCH_WORKER_LOCK = threading.Lock()
+    # the batched GPU path encodes one 30 s window, longer requests fall back to serial transcribe
+    BATCH_MAX_CHUNK_S = 30
 
     def __init__(
         self,
@@ -194,6 +197,12 @@ class ServeClientFasterWhisper(ServeClientBase):
             logging.info(f"Detected language {self.language} with probability {info.language_probability}")
             self.websocket.send(json.dumps(
                 {"uid": self.client_uid, "language": self.language, "language_prob": info.language_probability}))
+
+    def get_audio_chunk_for_processing(self):
+        input_bytes, duration = super().get_audio_chunk_for_processing()
+        if ServeClientFasterWhisper.BATCH_WORKER is None or duration <= self.BATCH_MAX_CHUNK_S:
+            return input_bytes, duration
+        return input_bytes[: self.BATCH_MAX_CHUNK_S * self.RATE], float(self.BATCH_MAX_CHUNK_S)
 
     def transcribe_audio(self, input_sample):
         """

--- a/whisper_live/backend/faster_whisper_backend.py
+++ b/whisper_live/backend/faster_whisper_backend.py
@@ -14,6 +14,7 @@ from whisper_live.backend.base import ServeClientBase
 class ServeClientFasterWhisper(ServeClientBase):
     SINGLE_MODEL = None
     SINGLE_MODEL_LOCK = threading.Lock()
+    BATCH_WAIT_TIMEOUT_SECONDS = 30
     BATCH_WORKER = None
 
     def __init__(
@@ -223,7 +224,11 @@ class ServeClientFasterWhisper(ServeClientBase):
                 client_uid=self.client_uid,
             )
             ServeClientFasterWhisper.BATCH_WORKER.submit(request)
-            request.future.wait(timeout=30)
+            if not request.future.wait(timeout=self.BATCH_WAIT_TIMEOUT_SECONDS):
+                request.abandoned = True
+                raise TimeoutError(
+                    f"batch inference gave no result within {self.BATCH_WAIT_TIMEOUT_SECONDS}s"
+                )
             if request.error:
                 raise request.error
             if self.language is None and request.info is not None:

--- a/whisper_live/backend/faster_whisper_backend.py
+++ b/whisper_live/backend/faster_whisper_backend.py
@@ -222,7 +222,7 @@ class ServeClientFasterWhisper(ServeClientBase):
         """
         # Batch inference path: submit to central queue and wait
         if ServeClientFasterWhisper.BATCH_WORKER is not None:
-            from whisper_live.batch_inference import BatchRequest
+            from whisper_live.batch_inference import BatchRequest, prepare_features
             request = BatchRequest(
                 audio=input_sample,
                 language=self.language,
@@ -234,6 +234,8 @@ class ServeClientFasterWhisper(ServeClientBase):
                 hotwords=self.hotwords,
                 client_uid=self.client_uid,
             )
+            if not request.word_timestamps:
+                prepare_features(self.transcriber, request)
             ServeClientFasterWhisper.BATCH_WORKER.submit(request)
             if not request.future.wait(timeout=self.BATCH_WAIT_TIMEOUT_SECONDS):
                 request.abandoned = True

--- a/whisper_live/backend/faster_whisper_backend.py
+++ b/whisper_live/backend/faster_whisper_backend.py
@@ -221,6 +221,7 @@ class ServeClientFasterWhisper(ServeClientBase):
                 use_vad=self.use_vad,
                 vad_parameters=self.vad_parameters if self.use_vad else None,
                 word_timestamps=self.word_timestamps,
+                hotwords=self.hotwords,
                 client_uid=self.client_uid,
             )
             ServeClientFasterWhisper.BATCH_WORKER.submit(request)

--- a/whisper_live/backend/faster_whisper_backend.py
+++ b/whisper_live/backend/faster_whisper_backend.py
@@ -100,10 +100,11 @@ class ServeClientFasterWhisper(ServeClientBase):
         try:
             if single_model:
                 if ServeClientFasterWhisper.SINGLE_MODEL is None:
-                    self.create_model(device)
-                    ServeClientFasterWhisper.SINGLE_MODEL = self.transcriber
-                else:
-                    self.transcriber = ServeClientFasterWhisper.SINGLE_MODEL
+                    with ServeClientFasterWhisper.SINGLE_MODEL_LOCK:
+                        if ServeClientFasterWhisper.SINGLE_MODEL is None:
+                            self.create_model(device)
+                            ServeClientFasterWhisper.SINGLE_MODEL = self.transcriber
+                self.transcriber = ServeClientFasterWhisper.SINGLE_MODEL
             else:
                 self.create_model(device)
         except Exception as e:

--- a/whisper_live/batch_inference.py
+++ b/whisper_live/batch_inference.py
@@ -67,6 +67,8 @@ class BatchRequest:
         result: List of ``Segment`` objects (filled by worker).
         info: ``TranscriptionInfo`` metadata (filled by worker).
         error: Exception instance if processing failed.
+        abandoned: Set by the session thread when it stopped waiting; the
+            worker skips such requests instead of spending GPU time on them.
     """
     audio: np.ndarray
     language: Optional[str] = None
@@ -82,6 +84,7 @@ class BatchRequest:
     result: Optional[Any] = None
     info: Optional[Any] = None
     error: Optional[Exception] = None
+    abandoned: bool = False
 
 
 class BatchInferenceWorker:
@@ -175,6 +178,10 @@ class BatchInferenceWorker:
                     batch.append(item)
                 except queue.Empty:
                     break
+
+            batch = [req for req in batch if not req.abandoned]
+            if not batch:
+                continue
 
             # Process the collected batch
             try:

--- a/whisper_live/batch_inference.py
+++ b/whisper_live/batch_inference.py
@@ -78,6 +78,7 @@ class BatchRequest:
         speech_duration: Seconds of audio left after VAD, filled by
             ``prepare_features``.  ``None`` means the request has not been
             preprocessed yet, ``0.0`` means VAD found no speech.
+        submitted_at: ``time.monotonic()`` stamp set by ``submit()``.
     """
     audio: np.ndarray
     language: Optional[str] = None
@@ -94,6 +95,7 @@ class BatchRequest:
     features: Optional[np.ndarray] = None
     speech_chunks: Optional[list] = None
     speech_duration: Optional[float] = None
+    submitted_at: float = 0.0
     # Results (filled by batch worker)
     result: Optional[Any] = None
     info: Optional[Any] = None
@@ -155,17 +157,24 @@ class BatchInferenceWorker:
         max_batch_size: Maximum number of requests per batch.
         batch_window_ms: Maximum time (ms) to wait for the batch to fill
             after the first request arrives.
+        max_queue_wait_s: Measured queue wait above which ``overloaded()``
+            reports True so the server can turn new clients away.
     """
+
+    QUEUE_WAIT_EMA_ALPHA = 0.2
 
     def __init__(
         self,
         transcriber,
         max_batch_size: int = 16,
         batch_window_ms: int = 50,
+        max_queue_wait_s: float = 2.0,
     ):
         self.transcriber = transcriber
         self.max_batch_size = max_batch_size
         self.batch_window_ms = batch_window_ms
+        self.max_queue_wait_s = max_queue_wait_s
+        self.queue_wait_s = 0.0
         self._queue: queue.Queue = queue.Queue()
         self._stop_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
@@ -193,7 +202,19 @@ class BatchInferenceWorker:
                 then call ``request.future.wait()`` to block until the
                 result is ready.
         """
+        request.submitted_at = time.monotonic()
         self._queue.put(request)
+
+    def overloaded(self) -> bool:
+        """Whether requests are waiting longer in the queue than allowed."""
+        return self.queue_wait_s > self.max_queue_wait_s
+
+    def _record_queue_wait(self, request: BatchRequest):
+        waited = time.monotonic() - request.submitted_at
+        self.queue_wait_s = (
+            self.QUEUE_WAIT_EMA_ALPHA * waited
+            + (1 - self.QUEUE_WAIT_EMA_ALPHA) * self.queue_wait_s
+        )
 
     # -------------------------------------------------------------------------
     # Worker loop
@@ -207,9 +228,11 @@ class BatchInferenceWorker:
             # Block until first request arrives
             try:
                 first = self._queue.get(timeout=0.5)
-                batch.append(first)
             except queue.Empty:
+                self.queue_wait_s = 0.0
                 continue
+            self._record_queue_wait(first)
+            batch.append(first)
 
             # Collect more requests within the batch window
             deadline = time.monotonic() + (self.batch_window_ms / 1000.0)
@@ -219,9 +242,10 @@ class BatchInferenceWorker:
                     break
                 try:
                     item = self._queue.get(timeout=remaining)
-                    batch.append(item)
                 except queue.Empty:
                     break
+                self._record_queue_wait(item)
+                batch.append(item)
 
             batch = [req for req in batch if not req.abandoned]
             if not batch:

--- a/whisper_live/batch_inference.py
+++ b/whisper_live/batch_inference.py
@@ -50,6 +50,9 @@ from whisper_live.transcriber.transcriber_faster_whisper import (
 )
 
 
+FALLBACK_TEMPERATURES = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
+
+
 @dataclass
 class BatchRequest:
     """A single inference request submitted by a session thread.
@@ -161,6 +164,9 @@ class BatchInferenceWorker:
         beam_size: Beam width for the first (temperature 0) decode of every
             item on both paths. Fallback decodes at higher temperatures sample
             with a beam of 1.
+        temperature_fallback: Re-decode items that fail the compression ratio
+            or log probability check at rising temperatures, like
+            ``transcriber.transcribe``. Off keeps the temperature 0 result.
         max_queue_wait_s: Measured queue wait above which ``overloaded()``
             reports True so the server can turn new clients away.
     """
@@ -174,9 +180,11 @@ class BatchInferenceWorker:
         batch_window_ms: int = 50,
         max_queue_wait_s: float = 2.0,
         beam_size: int = 5,
+        temperature_fallback: bool = True,
     ):
         self.transcriber = transcriber
         self.beam_size = beam_size
+        self.temperature_fallback = temperature_fallback
         self.max_batch_size = max_batch_size
         self.batch_window_ms = batch_window_ms
         self.max_queue_wait_s = max_queue_wait_s
@@ -413,7 +421,7 @@ class BatchInferenceWorker:
             # only failed items are re-decoded at the next temperature.
             suppress_tokens = get_suppressed_tokens(tokenizers_list[0], [-1])
 
-            temperatures = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
+            temperatures = FALLBACK_TEMPERATURES if self.temperature_fallback else [0.0]
             comp_thresh = 2.4
             logprob_thresh = -1.0
             no_speech_thresh = 0.6

--- a/whisper_live/batch_inference.py
+++ b/whisper_live/batch_inference.py
@@ -162,11 +162,13 @@ class BatchInferenceWorker:
         batch_window_ms: Maximum time (ms) to wait for the batch to fill
             after the first request arrives.
         beam_size: Beam width for the first (temperature 0) decode of every
-            item on both paths. Fallback decodes at higher temperatures sample
-            with a beam of 1.
+            item on both paths. Greedy (1) decodes about 2.5x faster than 5.
+            Fallback decodes at higher temperatures sample with a beam of 1.
         temperature_fallback: Re-decode items that fail the compression ratio
             or log probability check at rising temperatures, like
-            ``transcriber.transcribe``. Off keeps the temperature 0 result.
+            ``transcriber.transcribe``. Each extra pass costs about as much as
+            the first, which halves throughput at beam 1. Off keeps the
+            temperature 0 result.
         max_queue_wait_s: Measured queue wait above which ``overloaded()``
             reports True so the server can turn new clients away.
     """
@@ -179,8 +181,8 @@ class BatchInferenceWorker:
         max_batch_size: int = 16,
         batch_window_ms: int = 50,
         max_queue_wait_s: float = 2.0,
-        beam_size: int = 5,
-        temperature_fallback: bool = True,
+        beam_size: int = 1,
+        temperature_fallback: bool = False,
     ):
         self.transcriber = transcriber
         self.beam_size = beam_size

--- a/whisper_live/batch_inference.py
+++ b/whisper_live/batch_inference.py
@@ -73,6 +73,11 @@ class BatchRequest:
         error: Exception instance if processing failed.
         abandoned: Set by the session thread when it stopped waiting; the
             worker skips such requests instead of spending GPU time on them.
+        features: Mel spectrogram, filled by ``prepare_features``.
+        speech_chunks: VAD speech timestamps, filled by ``prepare_features``.
+        speech_duration: Seconds of audio left after VAD, filled by
+            ``prepare_features``.  ``None`` means the request has not been
+            preprocessed yet, ``0.0`` means VAD found no speech.
     """
     audio: np.ndarray
     language: Optional[str] = None
@@ -85,11 +90,45 @@ class BatchRequest:
     client_uid: Optional[str] = None
     # Signaling
     future: threading.Event = field(default_factory=threading.Event)
+    # Preprocessing (filled by prepare_features, in the session thread or the worker)
+    features: Optional[np.ndarray] = None
+    speech_chunks: Optional[list] = None
+    speech_duration: Optional[float] = None
     # Results (filled by batch worker)
     result: Optional[Any] = None
     info: Optional[Any] = None
     error: Optional[Exception] = None
     abandoned: bool = False
+
+
+def prepare_features(transcriber, request: BatchRequest):
+    """Run VAD and mel extraction for one request and store them on it.
+
+    Called from the session thread so the batch worker only does GPU work.
+    ``feature_extractor`` is stateless numpy and the silero VAD runs through
+    one thread safe onnxruntime session, so parallel calls are fine.
+    """
+    sampling_rate = transcriber.feature_extractor.sampling_rate
+    audio = request.audio
+    speech_chunks = None
+
+    if request.use_vad:
+        vad_params = request.vad_parameters or {}
+        vad_opts = VadOptions(**vad_params) if isinstance(vad_params, dict) else vad_params
+        speech_chunks = get_speech_timestamps(audio, vad_opts)
+        if speech_chunks:
+            audio_chunks, _ = collect_chunks(audio, speech_chunks)
+            audio = np.concatenate(audio_chunks, axis=0) if audio_chunks else audio
+
+    request.speech_chunks = speech_chunks
+
+    if audio.shape[0] == 0:
+        request.speech_duration = 0.0
+        return
+
+    request.speech_duration = audio.shape[0] / sampling_rate
+    features = transcriber.feature_extractor(audio)
+    request.features = pad_or_trim(features)  # -> [n_mels, 3000]
 
 
 class BatchInferenceWorker:
@@ -259,7 +298,8 @@ class BatchInferenceWorker:
         """Batched GPU path: encode + generate for multiple sessions at once.
 
         Pipeline:
-            1. Per-item CPU preprocessing (VAD filtering + mel feature extraction)
+            1. Per-item CPU preprocessing, unless the session thread already
+               ran ``prepare_features``
             2. Batch GPU encode — single ``transcriber.encode()`` call
             3. Per-item prompt construction (handles different languages/tasks)
             4. Batch GPU generate — single ``transcriber.model.generate()`` call
@@ -270,29 +310,20 @@ class BatchInferenceWorker:
         preprocessed = []
         for req in batch:
             try:
-                audio = req.audio
-                full_duration = audio.shape[0] / sampling_rate
-                speech_chunks = None
+                if req.speech_duration is None:
+                    prepare_features(self.transcriber, req)
 
-                if req.use_vad:
-                    vad_params = req.vad_parameters or {}
-                    vad_opts = VadOptions(**vad_params) if isinstance(vad_params, dict) else vad_params
-                    speech_chunks = get_speech_timestamps(audio, vad_opts)
-                    if speech_chunks:
-                        audio_chunks, _ = collect_chunks(audio, speech_chunks)
-                        audio = np.concatenate(audio_chunks, axis=0) if audio_chunks else audio
-
-                if audio.shape[0] == 0:
+                if req.speech_duration == 0:
                     # No speech detected — return empty result immediately
                     req.result = []
                     req.info = self._make_info(req, 0.0, 0.0)
                     req.future.set()
                     continue
 
-                duration = audio.shape[0] / sampling_rate
-                features = self.transcriber.feature_extractor(audio)
-                features = pad_or_trim(features)  # -> [n_mels, 3000]
-                preprocessed.append((req, features, duration, full_duration, speech_chunks))
+                full_duration = req.audio.shape[0] / sampling_rate
+                preprocessed.append(
+                    (req, req.features, req.speech_duration, full_duration, req.speech_chunks)
+                )
             except Exception as e:
                 req.error = e
                 req.future.set()

--- a/whisper_live/batch_inference.py
+++ b/whisper_live/batch_inference.py
@@ -191,13 +191,28 @@ class BatchInferenceWorker:
     # -------------------------------------------------------------------------
 
     def _process_batch(self, batch: List[BatchRequest]):
-        """Dispatch to single or multi-item processing."""
+        """Dispatch to single or multi-item processing.
+
+        The multi-item path encodes a single 30s mel window per item, so audio
+        longer than 30s would be truncated there. Such items are routed to the
+        single path instead (``transcriber.transcribe`` windows long audio).
+        """
         if len(batch) == 1:
             self._process_single(batch[0])
             return
 
-        logging.info(f"[BatchInference] Processing batch of {len(batch)}")
-        self._process_multi(batch)
+        window_samples = 30 * self.transcriber.feature_extractor.sampling_rate
+        long_items = [r for r in batch if r.audio.shape[0] > window_samples]
+        short_items = [r for r in batch if r.audio.shape[0] <= window_samples]
+
+        for req in long_items:
+            self._process_single(req)
+
+        if len(short_items) == 1:
+            self._process_single(short_items[0])
+        elif short_items:
+            logging.info(f"[BatchInference] Processing batch of {len(short_items)}")
+            self._process_multi(short_items)
 
     def _process_single(self, req: BatchRequest):
         """Process a single request using standard ``transcriber.transcribe()``.

--- a/whisper_live/batch_inference.py
+++ b/whisper_live/batch_inference.py
@@ -45,6 +45,7 @@ from whisper_live.transcriber.transcriber_faster_whisper import (
     TranscriptionInfo,
     get_compression_ratio,
     get_suppressed_tokens,
+    restore_speech_timestamps,
 )
 
 
@@ -255,10 +256,12 @@ class BatchInferenceWorker:
             5. Per-item segment parsing and result dispatch
         """
         # Step 1: Per-item CPU preprocessing (VAD + feature extraction)
+        sampling_rate = self.transcriber.feature_extractor.sampling_rate
         preprocessed = []
         for req in batch:
             try:
                 audio = req.audio
+                full_duration = audio.shape[0] / sampling_rate
                 speech_chunks = None
 
                 if req.use_vad:
@@ -276,10 +279,10 @@ class BatchInferenceWorker:
                     req.future.set()
                     continue
 
-                duration = audio.shape[0] / self.transcriber.feature_extractor.sampling_rate
+                duration = audio.shape[0] / sampling_rate
                 features = self.transcriber.feature_extractor(audio)
                 features = pad_or_trim(features)  # -> [n_mels, 3000]
-                preprocessed.append((req, features, audio, duration, speech_chunks))
+                preprocessed.append((req, features, duration, full_duration, speech_chunks))
             except Exception as e:
                 req.error = e
                 req.future.set()
@@ -297,7 +300,7 @@ class BatchInferenceWorker:
             prompts = []
             resolved_languages = []
 
-            for i, (req, features, audio, duration, speech_chunks) in enumerate(preprocessed):
+            for i, (req, *_) in enumerate(preprocessed):
                 lang = req.language
                 # If language unknown, detect from encoder output
                 if lang is None:
@@ -406,7 +409,7 @@ class BatchInferenceWorker:
                 pending_indices = next_pending
 
             # Step 5: Per-item segment parsing and result dispatch
-            for i, (req, features, audio, duration, speech_chunks) in enumerate(preprocessed):
+            for i, (req, features, duration, full_duration, speech_chunks) in enumerate(preprocessed):
                 try:
                     tokenizer = tokenizers_list[i]
                     gen_result, avg_logprob, used_temp = final_results[i]
@@ -442,9 +445,12 @@ class BatchInferenceWorker:
                             temperature=used_temp,
                         ))
 
+                    if speech_chunks:
+                        segments = list(restore_speech_timestamps(segments, speech_chunks, sampling_rate))
+
                     req.result = segments
                     req.info = self._make_info(
-                        req, duration, duration,
+                        req, full_duration, duration,
                         language=resolved_languages[i],
                     )
                 except Exception as e:

--- a/whisper_live/batch_inference.py
+++ b/whisper_live/batch_inference.py
@@ -40,6 +40,7 @@ from faster_whisper.vad import (
     get_speech_timestamps,
 )
 
+from whisper_live import metrics as wl_metrics
 from whisper_live.transcriber.transcriber_faster_whisper import (
     Segment,
     TranscriptionInfo,
@@ -157,6 +158,9 @@ class BatchInferenceWorker:
         max_batch_size: Maximum number of requests per batch.
         batch_window_ms: Maximum time (ms) to wait for the batch to fill
             after the first request arrives.
+        beam_size: Beam width for the first (temperature 0) decode of every
+            item on both paths. Fallback decodes at higher temperatures sample
+            with a beam of 1.
         max_queue_wait_s: Measured queue wait above which ``overloaded()``
             reports True so the server can turn new clients away.
     """
@@ -169,8 +173,10 @@ class BatchInferenceWorker:
         max_batch_size: int = 16,
         batch_window_ms: int = 50,
         max_queue_wait_s: float = 2.0,
+        beam_size: int = 5,
     ):
         self.transcriber = transcriber
+        self.beam_size = beam_size
         self.max_batch_size = max_batch_size
         self.batch_window_ms = batch_window_ms
         self.max_queue_wait_s = max_queue_wait_s
@@ -309,6 +315,7 @@ class BatchInferenceWorker:
                 vad_parameters=req.vad_parameters if req.use_vad else None,
                 hotwords=req.hotwords,
                 word_timestamps=req.word_timestamps,
+                beam_size=self.beam_size,
             )
             # Materialize the generator into a list
             req.result = list(result) if result is not None else []
@@ -431,7 +438,7 @@ class BatchInferenceWorker:
                 sub_prompts = [prompts[i] for i in pending_indices]
 
                 gen_kwargs = dict(
-                    beam_size=5 if temp == 0.0 else 1,
+                    beam_size=self.beam_size if temp == 0.0 else 1,
                     patience=1,
                     length_penalty=1,
                     max_length=self.transcriber.max_length,
@@ -472,6 +479,8 @@ class BatchInferenceWorker:
                     else:
                         next_pending.append(idx)
 
+                if next_pending:
+                    wl_metrics.track_batch_fallback(len(next_pending))
                 pending_indices = next_pending
 
             # Step 5: Per-item segment parsing and result dispatch

--- a/whisper_live/batch_inference.py
+++ b/whisper_live/batch_inference.py
@@ -64,6 +64,9 @@ class BatchRequest:
         initial_prompt: Optional prompt for Whisper conditioning.
         use_vad: Whether to apply Voice Activity Detection.
         vad_parameters: Parameters forwarded to ``VadOptions``.
+        hotwords: Optional phrases to bias decoding toward.
+        word_timestamps: Whether to compute per-word timings; such requests
+            take the single path, the batched path has no word alignment.
         future: Event signaled when the result is ready.
         result: List of ``Segment`` objects (filled by worker).
         info: ``TranscriptionInfo`` metadata (filled by worker).
@@ -78,6 +81,7 @@ class BatchRequest:
     use_vad: bool = True
     vad_parameters: Optional[Dict] = None
     word_timestamps: bool = False
+    hotwords: Optional[str] = None
     client_uid: Optional[str] = None
     # Signaling
     future: threading.Event = field(default_factory=threading.Event)
@@ -201,19 +205,23 @@ class BatchInferenceWorker:
     def _process_batch(self, batch: List[BatchRequest]):
         """Dispatch to single or multi-item processing.
 
-        The multi-item path encodes a single 30s mel window per item, so audio
-        longer than 30s would be truncated there. Such items are routed to the
-        single path instead (``transcriber.transcribe`` windows long audio).
+        The multi-item path encodes a single 30s mel window per item and has
+        no word alignment, so audio longer than 30s and requests wanting word
+        timestamps go through ``transcriber.transcribe`` one at a time.
         """
         if len(batch) == 1:
             self._process_single(batch[0])
             return
 
         window_samples = 30 * self.transcriber.feature_extractor.sampling_rate
-        long_items = [r for r in batch if r.audio.shape[0] > window_samples]
-        short_items = [r for r in batch if r.audio.shape[0] <= window_samples]
 
-        for req in long_items:
+        def needs_single_path(req):
+            return req.audio.shape[0] > window_samples or req.word_timestamps
+
+        single_items = [r for r in batch if needs_single_path(r)]
+        short_items = [r for r in batch if not needs_single_path(r)]
+
+        for req in single_items:
             self._process_single(req)
 
         if len(short_items) == 1:
@@ -236,6 +244,8 @@ class BatchInferenceWorker:
                 initial_prompt=req.initial_prompt,
                 vad_filter=req.use_vad,
                 vad_parameters=req.vad_parameters if req.use_vad else None,
+                hotwords=req.hotwords,
+                word_timestamps=req.word_timestamps,
             )
             # Materialize the generator into a list
             req.result = list(result) if result is not None else []
@@ -330,6 +340,7 @@ class BatchInferenceWorker:
                     tokenizer,
                     previous_tokens=previous_tokens,
                     without_timestamps=False,
+                    hotwords=req.hotwords,
                 )
                 tokenizers_list.append(tokenizer)
                 prompts.append(prompt)

--- a/whisper_live/batch_inference.py
+++ b/whisper_live/batch_inference.py
@@ -346,7 +346,7 @@ class BatchInferenceWorker:
             no_speech_thresh = 0.6
 
             n = len(preprocessed)
-            final_results = [None] * n  # tuples of (gen_result, avg_logprob, used_temp)
+            final_results = [None] * n  # tuples of (gen_result, avg_logprob, used_temp, is_silence)
             pending_indices = list(range(n))
 
             for temp in temperatures:
@@ -402,7 +402,7 @@ class BatchInferenceWorker:
                     )
 
                     if not bad or is_silence or temp == temperatures[-1]:
-                        final_results[idx] = (gen_result, avg_logprob, temp)
+                        final_results[idx] = (gen_result, avg_logprob, temp, is_silence)
                     else:
                         next_pending.append(idx)
 
@@ -412,9 +412,9 @@ class BatchInferenceWorker:
             for i, (req, features, duration, full_duration, speech_chunks) in enumerate(preprocessed):
                 try:
                     tokenizer = tokenizers_list[i]
-                    gen_result, avg_logprob, used_temp = final_results[i]
+                    gen_result, avg_logprob, used_temp, is_silence = final_results[i]
 
-                    tokens = gen_result.sequences_ids[0]
+                    tokens = [] if is_silence else gen_result.sequences_ids[0]
                     segment_size = int(ceil(duration) * self.transcriber.frames_per_second)
 
                     subsegments, _, _ = self.transcriber._split_segments_by_timestamps(

--- a/whisper_live/batch_inference.py
+++ b/whisper_live/batch_inference.py
@@ -121,7 +121,7 @@ class BatchInferenceWorker:
     def __init__(
         self,
         transcriber,
-        max_batch_size: int = 8,
+        max_batch_size: int = 16,
         batch_window_ms: int = 50,
     ):
         self.transcriber = transcriber

--- a/whisper_live/metrics.py
+++ b/whisper_live/metrics.py
@@ -53,6 +53,10 @@ try:
         "Total errors by type",
         ["type"],
     )
+    BATCH_FALLBACK_ITEMS = Counter(
+        "whisperlive_batch_fallback_items_total",
+        "Batched items re-decoded at a higher temperature after failing the quality check",
+    )
 
     _AVAILABLE = True
 
@@ -120,3 +124,8 @@ def track_rest_request(endpoint="/v1/audio/transcriptions", status="200"):
 def track_error(error_type="transcription"):
     if _AVAILABLE:
         ERRORS.labels(type=error_type).inc()
+
+
+def track_batch_fallback(items):
+    if _AVAILABLE:
+        BATCH_FALLBACK_ITEMS.inc(items)

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -183,6 +183,7 @@ class BackendType(Enum):
 
 class TranscriptionServer:
     RATE = 16000
+    SECONDS_PER_MINUTE = 60
 
     def __init__(self):
         self.client_manager = None
@@ -390,6 +391,24 @@ class TranscriptionServer:
             return audio_np.astype(np.float32) / 32768.0
         return np.frombuffer(frame_data, dtype=np.float32)
 
+    def is_batch_worker_overloaded(self, websocket, options):
+        """Whether the batch worker is behind, sending the client a WAIT if so.
+
+        The WAIT message carries minutes, matching ``ClientManager.is_server_full``.
+        """
+        from whisper_live.backend.faster_whisper_backend import ServeClientFasterWhisper
+
+        worker = ServeClientFasterWhisper.BATCH_WORKER
+        if worker is None or not worker.overloaded():
+            return False
+        response = {
+            "uid": options["uid"],
+            "status": "WAIT",
+            "message": worker.queue_wait_s / self.SECONDS_PER_MINUTE,
+        }
+        websocket.send(json.dumps(response))
+        return True
+
     def handle_new_connection(self, websocket, faster_whisper_custom_model_path,
                               whisper_tensorrt_path, trt_multilingual, trt_py_session=False):
         try:
@@ -402,6 +421,10 @@ class TranscriptionServer:
                 wl_metrics.track_connection_rejected(reason="full")
                 websocket.close()
                 return False  # Indicates that the connection should not continue
+            if self.is_batch_worker_overloaded(websocket, options):
+                wl_metrics.track_connection_rejected(reason="overloaded")
+                websocket.close()
+                return False
             audio_format = options.get("audio_format", "float32")
             if audio_format not in {"float32", "int16", "uint8"}:
                 raise ValueError(f"Unsupported audio_format: {audio_format}")
@@ -626,6 +649,7 @@ class TranscriptionServer:
             batch_enabled=False,
             batch_max_size=16,
             batch_window_ms=50,
+            batch_max_queue_wait_s=2.0,
             raw_pcm_input=False,
             metrics_port: int = 0,
             api_key: Optional[str] = None,
@@ -647,6 +671,9 @@ class TranscriptionServer:
             batch_window_ms (int): Maximum time in milliseconds to wait for
                 the batch to fill after the first request arrives. Defaults
                 to 50.
+            batch_max_queue_wait_s (float): Measured batch queue wait in
+                seconds above which new clients are turned away with a WAIT
+                message. Defaults to 2.0.
             segment_post_processor (callable, optional): A callable that receives
                 a transcription segment dict and returns a modified segment dict.
                 Applied to every segment before sending to the client. Useful for
@@ -669,6 +696,8 @@ class TranscriptionServer:
             raise ValueError(f"batch_max_size must be >= 1, got {batch_max_size}")
         if batch_enabled and batch_window_ms < 0:
             raise ValueError(f"batch_window_ms must be >= 0, got {batch_window_ms}")
+        if batch_enabled and batch_max_queue_wait_s <= 0:
+            raise ValueError(f"batch_max_queue_wait_s must be > 0, got {batch_max_queue_wait_s}")
 
         self.segment_post_processor = segment_post_processor
         self.transcript_finalizer = transcript_finalizer
@@ -685,6 +714,7 @@ class TranscriptionServer:
             self.batch_config = {
                 'max_batch_size': batch_max_size,
                 'batch_window_ms': batch_window_ms,
+                'max_queue_wait_s': batch_max_queue_wait_s,
             }
             logging.info(f"Batch inference enabled (max_batch={batch_max_size}, window={batch_window_ms}ms)")
         else:

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -318,15 +318,16 @@ class TranscriptionServer:
 
                 # Start batch inference worker on first client (after model is loaded)
                 if (self.batch_config is not None
-                        and ServeClientFasterWhisper.BATCH_WORKER is None
                         and ServeClientFasterWhisper.SINGLE_MODEL is not None):
-                    from whisper_live.batch_inference import BatchInferenceWorker
-                    worker = BatchInferenceWorker(
-                        transcriber=ServeClientFasterWhisper.SINGLE_MODEL,
-                        **self.batch_config,
-                    )
-                    worker.start()
-                    ServeClientFasterWhisper.BATCH_WORKER = worker
+                    with ServeClientFasterWhisper.BATCH_WORKER_LOCK:
+                        if ServeClientFasterWhisper.BATCH_WORKER is None:
+                            from whisper_live.batch_inference import BatchInferenceWorker
+                            worker = BatchInferenceWorker(
+                                transcriber=ServeClientFasterWhisper.SINGLE_MODEL,
+                                **self.batch_config,
+                            )
+                            worker.start()
+                            ServeClientFasterWhisper.BATCH_WORKER = worker
         except Exception as e:
             logging.error(e)
             return

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -679,8 +679,8 @@ class TranscriptionServer:
             batch_window_ms=50,
             batch_max_queue_wait_s=0.5,
             batch_max_admissions_per_s=5.0,
-            batch_beam_size=5,
-            batch_temperature_fallback=True,
+            batch_beam_size=1,
+            batch_temperature_fallback=False,
             raw_pcm_input=False,
             metrics_port: int = 0,
             api_key: Optional[str] = None,
@@ -708,11 +708,12 @@ class TranscriptionServer:
             batch_max_admissions_per_s (float): Most new clients admitted per
                 second in batch mode, the rest get a WAIT. Bounds the burst
                 that gets in before the queue wait reflects it. Defaults to 5.
-            batch_beam_size (int): Beam width for batched decoding. 1 is
-                greedy and several times faster than the default 5.
+            batch_beam_size (int): Beam width for batched decoding. The
+                default 1 is greedy, 5 matches ``transcriber.transcribe`` at
+                about 2.5x the decode time.
             batch_temperature_fallback (bool): Re-decode batched items that
                 fail the quality check at higher temperatures. Each fallback
-                pass costs about as much as the first. Defaults to True.
+                pass costs about as much as the first. Defaults to False.
             segment_post_processor (callable, optional): A callable that receives
                 a transcription segment dict and returns a modified segment dict.
                 Applied to every segment before sending to the client. Useful for

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -679,6 +679,7 @@ class TranscriptionServer:
             batch_window_ms=50,
             batch_max_queue_wait_s=0.5,
             batch_max_admissions_per_s=5.0,
+            batch_beam_size=5,
             raw_pcm_input=False,
             metrics_port: int = 0,
             api_key: Optional[str] = None,
@@ -706,6 +707,8 @@ class TranscriptionServer:
             batch_max_admissions_per_s (float): Most new clients admitted per
                 second in batch mode, the rest get a WAIT. Bounds the burst
                 that gets in before the queue wait reflects it. Defaults to 5.
+            batch_beam_size (int): Beam width for batched decoding. 1 is
+                greedy and several times faster than the default 5.
             segment_post_processor (callable, optional): A callable that receives
                 a transcription segment dict and returns a modified segment dict.
                 Applied to every segment before sending to the client. Useful for
@@ -732,6 +735,8 @@ class TranscriptionServer:
             raise ValueError(f"batch_max_queue_wait_s must be > 0, got {batch_max_queue_wait_s}")
         if batch_enabled and batch_max_admissions_per_s <= 0:
             raise ValueError(f"batch_max_admissions_per_s must be > 0, got {batch_max_admissions_per_s}")
+        if batch_enabled and batch_beam_size < 1:
+            raise ValueError(f"batch_beam_size must be >= 1, got {batch_beam_size}")
 
         self.segment_post_processor = segment_post_processor
         self.transcript_finalizer = transcript_finalizer
@@ -749,6 +754,7 @@ class TranscriptionServer:
                 'max_batch_size': batch_max_size,
                 'batch_window_ms': batch_window_ms,
                 'max_queue_wait_s': batch_max_queue_wait_s,
+                'beam_size': batch_beam_size,
             }
             self.admission_limiter = AdmissionRateLimiter(batch_max_admissions_per_s)
             logging.info(f"Batch inference enabled (max_batch={batch_max_size}, window={batch_window_ms}ms)")

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -181,6 +181,26 @@ class BackendType(Enum):
         return self == BackendType.OPENVINO
 
 
+class AdmissionRateLimiter:
+    """Token bucket that admits at most ``per_second`` clients per second."""
+
+    def __init__(self, per_second):
+        self.per_second = per_second
+        self.tokens = per_second
+        self.refilled_at = time.monotonic()
+        self.lock = threading.Lock()
+
+    def allow(self):
+        with self.lock:
+            now = time.monotonic()
+            self.tokens = min(self.per_second, self.tokens + (now - self.refilled_at) * self.per_second)
+            self.refilled_at = now
+            if self.tokens < 1:
+                return False
+            self.tokens -= 1
+            return True
+
+
 class TranscriptionServer:
     RATE = 16000
     SECONDS_PER_MINUTE = 60
@@ -191,6 +211,7 @@ class TranscriptionServer:
         self.use_vad = True
         self.single_model = False
         self.batch_config = None
+        self.admission_limiter = None
         self.raw_pcm_input = False
         self.audio_formats = {}
         self.segment_post_processor = None
@@ -391,23 +412,29 @@ class TranscriptionServer:
             return audio_np.astype(np.float32) / 32768.0
         return np.frombuffer(frame_data, dtype=np.float32)
 
-    def is_batch_worker_overloaded(self, websocket, options):
-        """Whether the batch worker is behind, sending the client a WAIT if so.
+    def batch_admission_refusal(self, websocket, options):
+        """Why a new client is turned away in batch mode, None when it may connect.
 
-        The WAIT message carries minutes, matching ``ClientManager.is_server_full``.
+        Refused clients get a WAIT carrying minutes, matching ``ClientManager.is_server_full``.
         """
         from whisper_live.backend.faster_whisper_backend import ServeClientFasterWhisper
 
         worker = ServeClientFasterWhisper.BATCH_WORKER
-        if worker is None or not worker.overloaded():
-            return False
+        if worker is None:
+            return None
+        if worker.overloaded():
+            reason = "overloaded"
+        elif self.admission_limiter is not None and not self.admission_limiter.allow():
+            reason = "rate_limited"
+        else:
+            return None
         response = {
             "uid": options["uid"],
             "status": "WAIT",
             "message": worker.queue_wait_s / self.SECONDS_PER_MINUTE,
         }
         websocket.send(json.dumps(response))
-        return True
+        return reason
 
     def handle_new_connection(self, websocket, faster_whisper_custom_model_path,
                               whisper_tensorrt_path, trt_multilingual, trt_py_session=False):
@@ -421,8 +448,9 @@ class TranscriptionServer:
                 wl_metrics.track_connection_rejected(reason="full")
                 websocket.close()
                 return False  # Indicates that the connection should not continue
-            if self.is_batch_worker_overloaded(websocket, options):
-                wl_metrics.track_connection_rejected(reason="overloaded")
+            refusal = self.batch_admission_refusal(websocket, options)
+            if refusal:
+                wl_metrics.track_connection_rejected(reason=refusal)
                 websocket.close()
                 return False
             audio_format = options.get("audio_format", "float32")
@@ -649,7 +677,8 @@ class TranscriptionServer:
             batch_enabled=False,
             batch_max_size=16,
             batch_window_ms=50,
-            batch_max_queue_wait_s=2.0,
+            batch_max_queue_wait_s=0.5,
+            batch_max_admissions_per_s=5.0,
             raw_pcm_input=False,
             metrics_port: int = 0,
             api_key: Optional[str] = None,
@@ -673,7 +702,10 @@ class TranscriptionServer:
                 to 50.
             batch_max_queue_wait_s (float): Measured batch queue wait in
                 seconds above which new clients are turned away with a WAIT
-                message. Defaults to 2.0.
+                message. Defaults to 0.5.
+            batch_max_admissions_per_s (float): Most new clients admitted per
+                second in batch mode, the rest get a WAIT. Bounds the burst
+                that gets in before the queue wait reflects it. Defaults to 5.
             segment_post_processor (callable, optional): A callable that receives
                 a transcription segment dict and returns a modified segment dict.
                 Applied to every segment before sending to the client. Useful for
@@ -698,6 +730,8 @@ class TranscriptionServer:
             raise ValueError(f"batch_window_ms must be >= 0, got {batch_window_ms}")
         if batch_enabled and batch_max_queue_wait_s <= 0:
             raise ValueError(f"batch_max_queue_wait_s must be > 0, got {batch_max_queue_wait_s}")
+        if batch_enabled and batch_max_admissions_per_s <= 0:
+            raise ValueError(f"batch_max_admissions_per_s must be > 0, got {batch_max_admissions_per_s}")
 
         self.segment_post_processor = segment_post_processor
         self.transcript_finalizer = transcript_finalizer
@@ -716,6 +750,7 @@ class TranscriptionServer:
                 'batch_window_ms': batch_window_ms,
                 'max_queue_wait_s': batch_max_queue_wait_s,
             }
+            self.admission_limiter = AdmissionRateLimiter(batch_max_admissions_per_s)
             logging.info(f"Batch inference enabled (max_batch={batch_max_size}, window={batch_window_ms}ms)")
         else:
             self.batch_config = None

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -624,7 +624,7 @@ class TranscriptionServer:
             enable_rest=False,
             cors_origins: Optional[str] = None,
             batch_enabled=False,
-            batch_max_size=8,
+            batch_max_size=16,
             batch_window_ms=50,
             raw_pcm_input=False,
             metrics_port: int = 0,
@@ -643,7 +643,7 @@ class TranscriptionServer:
                 forced to True and a ``BatchInferenceWorker`` is started after
                 the first client connects. Defaults to False.
             batch_max_size (int): Maximum number of requests per GPU batch.
-                Defaults to 8.
+                Defaults to 16.
             batch_window_ms (int): Maximum time in milliseconds to wait for
                 the batch to fill after the first request arrives. Defaults
                 to 50.

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -680,6 +680,7 @@ class TranscriptionServer:
             batch_max_queue_wait_s=0.5,
             batch_max_admissions_per_s=5.0,
             batch_beam_size=5,
+            batch_temperature_fallback=True,
             raw_pcm_input=False,
             metrics_port: int = 0,
             api_key: Optional[str] = None,
@@ -709,6 +710,9 @@ class TranscriptionServer:
                 that gets in before the queue wait reflects it. Defaults to 5.
             batch_beam_size (int): Beam width for batched decoding. 1 is
                 greedy and several times faster than the default 5.
+            batch_temperature_fallback (bool): Re-decode batched items that
+                fail the quality check at higher temperatures. Each fallback
+                pass costs about as much as the first. Defaults to True.
             segment_post_processor (callable, optional): A callable that receives
                 a transcription segment dict and returns a modified segment dict.
                 Applied to every segment before sending to the client. Useful for
@@ -755,6 +759,7 @@ class TranscriptionServer:
                 'batch_window_ms': batch_window_ms,
                 'max_queue_wait_s': batch_max_queue_wait_s,
                 'beam_size': batch_beam_size,
+                'temperature_fallback': batch_temperature_fallback,
             }
             self.admission_limiter = AdmissionRateLimiter(batch_max_admissions_per_s)
             logging.info(f"Batch inference enabled (max_batch={batch_max_size}, window={batch_window_ms}ms)")

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -193,6 +193,7 @@ class TranscriptionServer:
         self.raw_pcm_input = False
         self.audio_formats = {}
         self.segment_post_processor = None
+        self.transcript_finalizer = None
 
     def initialize_client(
         self, websocket, options, faster_whisper_custom_model_path,
@@ -337,6 +338,10 @@ class TranscriptionServer:
         if self.segment_post_processor is not None:
             client.segment_post_processor = self.segment_post_processor
 
+        # Attach end-of-stream finalizer if configured
+        if self.transcript_finalizer is not None:
+            client.transcript_finalizer = self.transcript_finalizer
+
         if translation_client:
             client.translation_client = translation_client
             client.translation_thread = translation_thread
@@ -476,6 +481,11 @@ class TranscriptionServer:
             while not self.client_manager.is_client_timeout(websocket):
                 if not self.process_audio_frames(websocket):
                     break
+            # stream ended normally (END_OF_AUDIO or timeout); socket still open,
+            # so run any end-of-stream finalizer before cleanup closes it.
+            client = self.client_manager.get_client(websocket)
+            if client:
+                client.finalize()
         except ConnectionClosed:
             logging.info("Connection closed by client")
         except Exception as e:
@@ -619,7 +629,8 @@ class TranscriptionServer:
             metrics_port: int = 0,
             api_key: Optional[str] = None,
             rate_limit_rpm: int = 0,
-            segment_post_processor=None):
+            segment_post_processor=None,
+            transcript_finalizer=None):
         """
         Run the transcription server.
 
@@ -640,6 +651,11 @@ class TranscriptionServer:
                 Applied to every segment before sending to the client. Useful for
                 plugging in custom post-processing (e.g. formatting, redaction).
                 Defaults to None.
+            transcript_finalizer (callable, optional): A callable that receives the
+                accumulated transcript (list of segment dicts) once the stream ends,
+                while the socket is still open, and may return a dict sent to the
+                client as a final message. Useful for cross-segment results (e.g.
+                paragraph grouping). Defaults to None.
         """
         self.cache_path = cache_path
         self.raw_pcm_input = raw_pcm_input
@@ -654,6 +670,7 @@ class TranscriptionServer:
             raise ValueError(f"batch_window_ms must be >= 0, got {batch_window_ms}")
 
         self.segment_post_processor = segment_post_processor
+        self.transcript_finalizer = transcript_finalizer
         self.client_manager = ClientManager(max_clients, max_connection_time)
         if faster_whisper_custom_model_path is not None and not os.path.exists(faster_whisper_custom_model_path):
             if "/" not in faster_whisper_custom_model_path:


### PR DESCRIPTION
fixes found load testing `--batch_inference`, plus the end-of-stream hook that work needs. one commit each, tests in `tests/test_batch_inference.py`, `tests/test_batch_timeout.py` and `tests/test_server_extended.py`.

- `transcript_finalizer` hook: runs once when a stream ends, return value sent to the client as a final message
- batched path truncated audio over 30 s
- batch wait timeout was treated as silence and dropped audio: now raises and retries, worker skips abandoned requests
- batched path returned VAD-collapsed timestamps
- batched path emitted text for segments already judged silence
- `hotwords` dropped in both batch paths, `word_timestamps` in the batched one
- single-model load and batch worker start raced under concurrent first connections
- a timed out chunk is dropped instead of resubmitted, session loop waits on the frames event instead of fixed sleeps
- batch requests capped at 30 s so none fall back to the serial path, default batch size 16
- VAD and mel extraction moved from the worker thread to the session thread
- new clients get WAIT when the measured batch queue wait exceeds `batch_max_queue_wait_s`, admissions rate limited by `batch_max_admissions_per_s`
- `batch_beam_size` option, `batch_temperature_fallback` switch, `whisperlive_batch_fallback_items_total` counter for fallback re-decodes

