### PR TITLE
rest health, model selection, language metadata, audio preprocessor hook

### DIFF
--- a/run_server.py
+++ b/run_server.py
@@ -104,6 +104,13 @@ if __name__ == "__main__":
              'Clients must send "Authorization: Bearer <key>" header or "?token=<key>" query parameter.'
     )
     parser.add_argument(
+        '--default_model',
+        type=str,
+        default='small',
+        help='faster-whisper model the REST endpoint loads when the request does not name one '
+             '(default: small). Overridden by --faster_whisper_custom_model_path.'
+    )
+    parser.add_argument(
         '--rate_limit_rpm',
         type=int,
         default=0,
@@ -142,4 +149,5 @@ if __name__ == "__main__":
         metrics_port=args.metrics_port,
         api_key=args.api_key,
         rate_limit_rpm=args.rate_limit_rpm,
+        default_model=args.default_model,
     )

--- a/tests/test_client_extended.py
+++ b/tests/test_client_extended.py
@@ -320,5 +320,78 @@ class TestClientReconnect(unittest.TestCase):
         client.close_websocket()
 
 
+class TestClientReconnectOnlyOnUnexpectedClose(unittest.TestCase):
+    """Only closes the client did not ask for should trigger a reconnect."""
+
+    @patch("whisper_live.client.websocket.WebSocketApp")
+    @patch("whisper_live.client.pyaudio.PyAudio")
+    def setUp(self, mock_pyaudio, mock_websocket):
+        mock_pyaudio.return_value.open.return_value = MagicMock()
+        self.client = Client(host="localhost", port=9090, lang="en", max_retries=2, retry_delay=0)
+
+    def tearDown(self):
+        self.client.close_websocket()
+
+    def _disconnect_message(self):
+        return json.dumps({"uid": self.client.uid, "message": "DISCONNECT"})
+
+    def test_no_reconnect_after_close_websocket(self):
+        self.client.close_websocket()
+        self.client.on_close(MagicMock(), 1006, "abnormal closure")
+        self.assertEqual(self.client._retry_count, 0)
+
+    def test_no_reconnect_after_end_of_audio(self):
+        self.client.send_packet_to_server(Client.END_OF_AUDIO.encode("utf-8"))
+        self.client.on_close(MagicMock(), 1006, "server closed after final segment")
+        self.assertEqual(self.client._retry_count, 0)
+
+    def test_no_reconnect_on_normal_close_after_disconnect(self):
+        self.client.on_message(MagicMock(), self._disconnect_message())
+        self.client.on_close(MagicMock(), Client.NORMAL_CLOSURE, "normal")
+        self.assertEqual(self.client._retry_count, 0)
+
+    def test_reconnect_on_abnormal_close_after_disconnect(self):
+        self.client.on_message(MagicMock(), self._disconnect_message())
+        self.client.on_close(MagicMock(), 1006, "abnormal closure")
+        self.assertEqual(self.client._retry_count, 1)
+
+    def test_reconnect_on_normal_close_without_disconnect(self):
+        self.client.on_close(MagicMock(), Client.NORMAL_CLOSURE, "normal")
+        self.assertEqual(self.client._retry_count, 1)
+
+    def test_audio_packets_do_not_mark_a_client_close(self):
+        self.client.send_packet_to_server(b"\x00\x01\x02\x03")
+        self.assertFalse(self.client._client_initiated_close)
+        self.client.on_close(MagicMock(), 1006, "abnormal closure")
+        self.assertEqual(self.client._retry_count, 1)
+
+
+class TestClientKnownSpeakers(unittest.TestCase):
+    """Known speaker references are sent in the handshake."""
+
+    @patch("whisper_live.client.websocket.WebSocketApp")
+    @patch("whisper_live.client.pyaudio.PyAudio")
+    def _make_client(self, mock_pyaudio, mock_websocket, **kwargs):
+        mock_pyaudio.return_value.open.return_value = MagicMock()
+        return Client(host="localhost", port=9090, lang="en", **kwargs)
+
+    def test_known_speakers_included_in_handshake(self):
+        speakers = [{"name": "alice", "audio_base64": "UklGRmZha2U="}]
+        client = self._make_client(known_speakers=speakers)
+        ws = MagicMock()
+        client.on_open(ws)
+        sent = json.loads(ws.send.call_args[0][0])
+        self.assertEqual(sent["known_speakers"], speakers)
+        client.close_websocket()
+
+    def test_handshake_defaults_to_no_known_speakers(self):
+        client = self._make_client()
+        ws = MagicMock()
+        client.on_open(ws)
+        sent = json.loads(ws.send.call_args[0][0])
+        self.assertEqual(sent["known_speakers"], [])
+        client.close_websocket()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -696,5 +696,481 @@ class TestWebSocketAuth(unittest.TestCase):
         self.assertEqual(result[0], 401)
 
 
+def _make_transcription_info(language="en", language_probability=0.97, duration=1.0):
+    info = MagicMock()
+    info.language = language
+    info.language_probability = language_probability
+    info.duration = duration
+    return info
+
+
+def _make_segment(index=0, text=" hello ", start=0.0, end=1.0):
+    seg = MagicMock()
+    seg.id = index
+    seg.seek = 0
+    seg.start = start
+    seg.end = end
+    seg.text = text
+    seg.tokens = []
+    seg.temperature = 0.0
+    seg.avg_logprob = -0.1
+    seg.compression_ratio = 1.2
+    seg.no_speech_prob = 0.01
+    seg.words = []
+    return seg
+
+
+class TestHealthEndpoint(unittest.TestCase):
+    """Tests for the REST /health route built by build_rest_app()."""
+
+    def _make_client(self, api_key=None, **kwargs):
+        from fastapi.testclient import TestClient
+
+        self.server = TranscriptionServer()
+        self.server.client_manager = ClientManager(max_clients=3, max_connection_time=60)
+        app = self.server.build_rest_app("faster_whisper", api_key=api_key, **kwargs)
+        return TestClient(app)
+
+    def test_health_reports_backend_model_and_clients(self):
+        client = self._make_client()
+        self.server.client_manager.add_client(MagicMock(), MagicMock())
+        resp = client.get("/health")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp.json(),
+            {
+                "status": "ok",
+                "backend": "faster_whisper",
+                "model": "small",
+                "clients": 1,
+                "max_clients": 3,
+            },
+        )
+
+    def test_health_reports_default_model_override(self):
+        from fastapi.testclient import TestClient
+
+        server = TranscriptionServer()
+        server.default_model = "large-v3"
+        server.client_manager = ClientManager(max_clients=2, max_connection_time=60)
+        client = TestClient(server.build_rest_app("faster_whisper"))
+        self.assertEqual(client.get("/health").json()["model"], "large-v3")
+
+    def test_health_reports_custom_model_path(self):
+        client = self._make_client(faster_whisper_custom_model_path="org/custom-model")
+        self.assertEqual(client.get("/health").json()["model"], "org/custom-model")
+
+    def test_health_needs_no_api_key(self):
+        client = self._make_client(api_key="test-secret")
+        resp = client.get("/health")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["status"], "ok")
+
+    def test_health_works_with_api_key_header(self):
+        client = self._make_client(api_key="test-secret")
+        resp = client.get("/health", headers={"Authorization": "Bearer test-secret"})
+        self.assertEqual(resp.status_code, 200)
+
+    def test_docs_routes_need_no_api_key(self):
+        client = self._make_client(api_key="test-secret")
+        for path in ("/docs", "/redoc", "/openapi.json"):
+            with self.subTest(path=path):
+                self.assertEqual(client.get(path).status_code, 200)
+
+    def test_transcriptions_still_requires_api_key(self):
+        import io
+
+        client = self._make_client(api_key="test-secret")
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+        )
+        self.assertEqual(resp.status_code, 401)
+
+
+class TestRestModelSelection(unittest.TestCase):
+    """Tests for _resolve_rest_model() and the REST model cache."""
+
+    def setUp(self):
+        self.server = TranscriptionServer()
+
+    def test_whisper_1_alias_uses_default(self):
+        self.assertEqual(self.server._resolve_rest_model("whisper-1"), "small")
+
+    def test_missing_model_uses_default(self):
+        self.assertEqual(self.server._resolve_rest_model(None), "small")
+        self.assertEqual(self.server._resolve_rest_model(""), "small")
+
+    def test_default_model_is_configurable(self):
+        self.server.default_model = "medium"
+        self.assertEqual(self.server._resolve_rest_model("whisper-1"), "medium")
+
+    def test_stock_sizes_are_honoured(self):
+        for name in ("tiny", "base", "small", "medium", "large-v2", "large-v3", "large-v3-turbo"):
+            with self.subTest(name=name):
+                self.assertEqual(self.server._resolve_rest_model(name), name)
+
+    def test_english_only_variants_are_honoured(self):
+        for name in ("tiny.en", "base.en", "small.en", "medium.en"):
+            with self.subTest(name=name):
+                self.assertEqual(self.server._resolve_rest_model(name), name)
+
+    def test_hf_repo_id_is_honoured(self):
+        self.assertEqual(self.server._resolve_rest_model("deepdml/faster-whisper-x"), "deepdml/faster-whisper-x")
+
+    def test_local_path_is_honoured(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as model_dir:
+            self.assertEqual(self.server._resolve_rest_model(model_dir), model_dir)
+
+    def test_unknown_name_falls_back_to_default(self):
+        self.server.default_model = "base"
+        self.assertEqual(self.server._resolve_rest_model("gpt-4o-transcribe"), "base")
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_model_is_loaded_once_per_name(self, mock_model_cls):
+        first = self.server._get_rest_model("small")
+        second = self.server._get_rest_model("small")
+        self.assertIs(first, second)
+        mock_model_cls.assert_called_once()
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_different_names_load_separate_models(self, mock_model_cls):
+        mock_model_cls.side_effect = [MagicMock(name="small"), MagicMock(name="medium")]
+        small = self.server._get_rest_model("small")
+        medium = self.server._get_rest_model("medium")
+        self.assertIsNot(small, medium)
+        self.assertEqual(mock_model_cls.call_count, 2)
+        self.assertEqual(set(self.server.rest_models), {"small", "medium"})
+
+    @patch("whisper_live.server.serve")
+    def test_run_threads_default_model(self, mock_serve):
+        server = TranscriptionServer()
+        server.run("0.0.0.0", backend="faster_whisper", default_model="large-v3")
+        self.assertEqual(server.default_model, "large-v3")
+
+    @patch("whisper_live.server.serve")
+    def test_custom_model_path_outranks_default_model(self, mock_serve):
+        server = TranscriptionServer()
+        server.run(
+            "0.0.0.0",
+            backend="faster_whisper",
+            faster_whisper_custom_model_path="org/custom-model",
+            default_model="large-v3",
+        )
+        self.assertEqual(server.default_model, "org/custom-model")
+
+
+class TestRestTranscribeModelAndLanguage(unittest.TestCase):
+    """Tests that the REST endpoint honours `model` and reports language."""
+
+    def setUp(self):
+        self.server = TranscriptionServer()
+        self.server.client_manager = ClientManager(max_clients=2, max_connection_time=60)
+
+    def _post(self, mock_model_cls, **fields):
+        import io
+        from fastapi.testclient import TestClient
+
+        transcriber = MagicMock()
+        transcriber.transcribe.return_value = (iter([_make_segment()]), _make_transcription_info())
+        mock_model_cls.return_value = transcriber
+        self.transcriber = transcriber
+
+        client = TestClient(self.server.build_rest_app("faster_whisper"))
+        return client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+            data=fields,
+        )
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_stock_model_name_is_loaded(self, mock_model_cls):
+        resp = self._post(mock_model_cls, model="medium")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(mock_model_cls.call_args[0][0], "medium")
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_whisper_1_loads_default_model(self, mock_model_cls):
+        self.server.default_model = "base"
+        resp = self._post(mock_model_cls, model="whisper-1")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(mock_model_cls.call_args[0][0], "base")
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_repeated_requests_reuse_cached_model(self, mock_model_cls):
+        import io
+        from fastapi.testclient import TestClient
+
+        transcriber = MagicMock()
+        transcriber.transcribe.side_effect = lambda *a, **k: (
+            iter([_make_segment()]), _make_transcription_info()
+        )
+        mock_model_cls.return_value = transcriber
+
+        client = TestClient(self.server.build_rest_app("faster_whisper"))
+        for _ in range(3):
+            resp = client.post(
+                "/v1/audio/transcriptions",
+                files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+                data={"model": "small"},
+            )
+            self.assertEqual(resp.status_code, 200)
+        mock_model_cls.assert_called_once()
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_json_response_includes_language(self, mock_model_cls):
+        resp = self._post(mock_model_cls, response_format="json")
+        body = resp.json()
+        self.assertEqual(body["text"], "hello")
+        self.assertEqual(body["language"], "en")
+        self.assertAlmostEqual(body["language_probability"], 0.97)
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_verbose_json_includes_language_probability(self, mock_model_cls):
+        resp = self._post(mock_model_cls, response_format="verbose_json")
+        body = resp.json()
+        self.assertEqual(body["language"], "en")
+        self.assertAlmostEqual(body["language_probability"], 0.97)
+
+
+class TestStreamLanguageEvent(unittest.TestCase):
+    """The SSE stream must announce the detected language before any segment."""
+
+    def _stream(self, mock_model_cls, language_probability=0.91):
+        import io
+        from fastapi.testclient import TestClient
+
+        transcriber = MagicMock()
+        transcriber.transcribe.return_value = (
+            iter([_make_segment(text=" hello world ")]),
+            _make_transcription_info(language="de", language_probability=language_probability),
+        )
+        mock_model_cls.return_value = transcriber
+
+        server = TranscriptionServer()
+        server.client_manager = ClientManager(max_clients=2, max_connection_time=60)
+        client = TestClient(server.build_rest_app("faster_whisper"))
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+            data={"stream": "true"},
+        )
+        events = [
+            json.loads(line.removeprefix("data: "))
+            for line in resp.text.split("\n")
+            if line.startswith("data: ") and "[DONE]" not in line
+        ]
+        return events
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_first_event_carries_language(self, mock_model_cls):
+        events = self._stream(mock_model_cls)
+        self.assertEqual(events[0]["language"], "de")
+        self.assertAlmostEqual(events[0]["language_probability"], 0.91)
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_language_event_precedes_segments(self, mock_model_cls):
+        events = self._stream(mock_model_cls)
+        self.assertNotIn("text", events[0])
+        self.assertEqual(events[1]["text"], "hello world")
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_stream_honours_model_field(self, mock_model_cls):
+        import io
+        from fastapi.testclient import TestClient
+
+        transcriber = MagicMock()
+        transcriber.transcribe.return_value = (iter([]), _make_transcription_info())
+        mock_model_cls.return_value = transcriber
+
+        server = TranscriptionServer()
+        server.client_manager = ClientManager(max_clients=2, max_connection_time=60)
+        client = TestClient(server.build_rest_app("faster_whisper"))
+        client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+            data={"stream": "true", "model": "large-v3"},
+        )
+        self.assertEqual(mock_model_cls.call_args[0][0], "large-v3")
+
+
+class TestAudioPreprocessor(unittest.TestCase):
+    """Tests for the optional audio_preprocessor hook."""
+
+    def setUp(self):
+        self.server = TranscriptionServer()
+        self.server.backend = BackendType.FASTER_WHISPER
+        self.server.client_manager = ClientManager(max_clients=2, max_connection_time=60)
+
+    def _add_client(self, preprocessor):
+        import numpy as np
+
+        ws = MagicMock()
+        ws.recv.return_value = np.array([0.1, 0.2, 0.3], dtype=np.float32).tobytes()
+        client = MagicMock()
+        client.audio_preprocessor = preprocessor
+        self.server.client_manager.add_client(ws, client)
+        return ws, client
+
+    def test_preprocessor_output_reaches_add_frames(self):
+        import numpy as np
+
+        gained = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        ws, client = self._add_client(lambda frame, rate: gained)
+        self.assertTrue(self.server.process_audio_frames(ws))
+        np.testing.assert_array_equal(client.add_frames.call_args[0][0], gained)
+
+    def test_preprocessor_receives_frame_and_sample_rate(self):
+        import numpy as np
+
+        seen = {}
+
+        def preprocessor(frame, sample_rate):
+            seen["frame"] = frame
+            seen["sample_rate"] = sample_rate
+            return frame
+
+        ws, _ = self._add_client(preprocessor)
+        self.server.process_audio_frames(ws)
+        self.assertEqual(seen["sample_rate"], TranscriptionServer.RATE)
+        np.testing.assert_allclose(seen["frame"], [0.1, 0.2, 0.3], rtol=1e-6)
+
+    def test_no_preprocessor_leaves_frame_untouched(self):
+        import numpy as np
+
+        ws, client = self._add_client(None)
+        self.server.process_audio_frames(ws)
+        np.testing.assert_allclose(client.add_frames.call_args[0][0], [0.1, 0.2, 0.3], rtol=1e-6)
+
+    def test_failing_preprocessor_does_not_break_the_stream(self):
+        import numpy as np
+
+        def preprocessor(frame, sample_rate):
+            raise RuntimeError("denoiser exploded")
+
+        ws, client = self._add_client(preprocessor)
+        self.assertTrue(self.server.process_audio_frames(ws))
+        np.testing.assert_allclose(client.add_frames.call_args[0][0], [0.1, 0.2, 0.3], rtol=1e-6)
+
+    def test_preprocessor_runs_before_vad_for_tensorrt(self):
+        import numpy as np
+
+        self.server.backend = BackendType.TENSORRT
+        self.server.use_vad = True
+        denoised = np.array([0.9, 0.9, 0.9], dtype=np.float32)
+        ws, client = self._add_client(lambda frame, rate: denoised)
+        self.server.vad_detector = MagicMock(return_value=True)
+        self.server.process_audio_frames(ws)
+        np.testing.assert_array_equal(self.server.vad_detector.call_args[0][0], denoised)
+
+    @patch("whisper_live.server.serve")
+    def test_run_stores_preprocessor(self, mock_serve):
+        def preprocessor(frame, sample_rate):
+            return frame
+
+        server = TranscriptionServer()
+        server.run("0.0.0.0", backend="faster_whisper", audio_preprocessor=preprocessor)
+        self.assertIs(server.audio_preprocessor, preprocessor)
+
+    def test_initialize_client_attaches_preprocessor(self):
+        def preprocessor(frame, sample_rate):
+            return frame
+
+        server = TranscriptionServer()
+        server.backend = BackendType.FASTER_WHISPER
+        server.cache_path = "~/.cache/whisper-live/"
+        server.client_manager = ClientManager(max_clients=2, max_connection_time=60)
+        ws = MagicMock()
+        options = {"uid": "abc", "language": "en", "task": "transcribe", "model": "small"}
+        with patch("whisper_live.backend.faster_whisper_backend.ServeClientFasterWhisper") as mock_backend:
+            server.initialize_client(ws, options, None, None, False, audio_preprocessor=preprocessor)
+        client = server.client_manager.get_client(ws)
+        self.assertIs(client.audio_preprocessor, preprocessor)
+
+
+class TestKnownSpeakersOverWebSocket(unittest.TestCase):
+    """Tests for known_speakers enrollment sent in the WebSocket handshake."""
+
+    def setUp(self):
+        self.server = TranscriptionServer()
+        self.diarizer = MagicMock()
+        self.diarizer.enroll_speaker.return_value = True
+
+    def _options(self, **extra):
+        import base64
+
+        options = {
+            "uid": "abc",
+            "known_speakers": [
+                {"name": "alice", "audio_base64": base64.b64encode(b"RIFFfake").decode()},
+            ],
+        }
+        options.update(extra)
+        return options
+
+    def _create_diarizer(self, options):
+        import numpy as np
+
+        with patch("whisper_live.diarization.SpeakerDiarizer", return_value=self.diarizer), \
+                patch("whisper_live.diarization.load_audio", return_value=np.zeros(16000, dtype="float32")):
+            return self.server._create_diarizer(options)
+
+    def test_known_speakers_alone_create_a_diarizer(self):
+        diarizer = self._create_diarizer(self._options())
+        self.assertIs(diarizer, self.diarizer)
+
+    def test_known_speakers_are_enrolled(self):
+        self._create_diarizer(self._options())
+        self.diarizer.enroll_speaker.assert_called_once()
+        self.assertEqual(self.diarizer.enroll_speaker.call_args[0][0], "alice")
+
+    def test_multiple_known_speakers_enrolled(self):
+        import base64
+
+        speakers = [
+            {"name": "alice", "audio_base64": base64.b64encode(b"RIFFa").decode()},
+            {"name": "bob", "audio_base64": base64.b64encode(b"RIFFb").decode()},
+        ]
+        self._create_diarizer({"uid": "abc", "known_speakers": speakers})
+        enrolled = [call[0][0] for call in self.diarizer.enroll_speaker.call_args_list]
+        self.assertEqual(enrolled, ["alice", "bob"])
+
+    def test_no_known_speakers_and_no_diarization_returns_none(self):
+        self.assertIsNone(self.server._create_diarizer({"uid": "abc"}))
+
+    def test_diarization_without_known_speakers_enrolls_nothing(self):
+        diarizer = self._create_diarizer({"uid": "abc", "enable_diarization": True})
+        self.assertIs(diarizer, self.diarizer)
+        self.diarizer.enroll_speaker.assert_not_called()
+
+    def test_speaker_without_audio_is_skipped(self):
+        self._create_diarizer({"uid": "abc", "known_speakers": [{"name": "alice"}]})
+        self.diarizer.enroll_speaker.assert_not_called()
+
+    def test_invalid_base64_does_not_raise(self):
+        import numpy as np
+
+        with patch("whisper_live.diarization.load_audio", return_value=np.zeros(16000, dtype="float32")):
+            TranscriptionServer._enroll_known_speakers(
+                self.diarizer,
+                [{"name": "alice", "audio_base64": "not base64 @@@"}],
+            )
+        self.diarizer.enroll_speaker.assert_not_called()
+
+    def test_too_short_reference_is_reported_not_raised(self):
+        import base64
+        import numpy as np
+
+        self.diarizer.enroll_speaker.return_value = False
+        with patch("whisper_live.diarization.load_audio", return_value=np.zeros(10, dtype="float32")):
+            TranscriptionServer._enroll_known_speakers(
+                self.diarizer,
+                [{"name": "alice", "audio_base64": base64.b64encode(b"RIFFa").decode()}],
+            )
+        self.diarizer.enroll_speaker.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -8,7 +8,14 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 from websockets.http11 import Request
 
-from whisper_live.server import TranscriptionServer, BackendType, ClientManager, _websocket_auth
+from whisper_live.server import (
+    BEARER_SUBPROTOCOL,
+    TranscriptionServer,
+    BackendType,
+    ClientManager,
+    _select_bearer_subprotocol,
+    _websocket_auth,
+)
 
 
 class TestClientManagerAddRemove(unittest.TestCase):
@@ -694,6 +701,74 @@ class TestWebSocketAuth(unittest.TestCase):
         handler = self._make_auth_handler("my-secret")
         result = handler("/?token=wrong", {})
         self.assertEqual(result[0], 401)
+
+
+class TestBearerSubprotocolSelection(unittest.TestCase):
+    """Tests for the select_subprotocol callback passed to serve()."""
+
+    def test_bearer_offer_is_echoed(self):
+        selected = _select_bearer_subprotocol(MagicMock(), [BEARER_SUBPROTOCOL, "a.jwt.token"])
+        self.assertEqual(selected, BEARER_SUBPROTOCOL)
+
+    def test_the_token_is_never_selected(self):
+        selected = _select_bearer_subprotocol(MagicMock(), ["a.jwt.token"])
+        self.assertIsNone(selected)
+
+    def test_no_offer_selects_nothing(self):
+        self.assertIsNone(_select_bearer_subprotocol(MagicMock(), []))
+
+
+class TestRunWebsocketAuthWiring(unittest.TestCase):
+    """Tests that run() wires websocket_auth and the subprotocol into serve()."""
+
+    def _serve_kwargs(self, mock_serve, **run_kwargs):
+        TranscriptionServer().run("0.0.0.0", backend="faster_whisper", **run_kwargs)
+        return mock_serve.call_args.kwargs
+
+    def _refuse(self, connection, request):
+        return connection.respond(HTTPStatus.UNAUTHORIZED, "Unauthorized\n")
+
+    @patch("whisper_live.server.serve")
+    def test_subprotocol_is_always_selected(self, mock_serve):
+        kwargs = self._serve_kwargs(mock_serve)
+        self.assertIs(kwargs["select_subprotocol"], _select_bearer_subprotocol)
+        self.assertNotIn("process_request", kwargs)
+
+    @patch("whisper_live.server.serve")
+    def test_websocket_auth_becomes_process_request(self, mock_serve):
+        kwargs = self._serve_kwargs(mock_serve, websocket_auth=self._refuse)
+        connection = MagicMock()
+        connection.respond.return_value = (401, [], b"Unauthorized\n")
+        result = kwargs["process_request"](connection, Request("/", {}))
+        self.assertEqual(result[0], 401)
+
+    @patch("whisper_live.server.serve")
+    def test_the_api_key_alone_does_not_admit_a_connection(self, mock_serve):
+        kwargs = self._serve_kwargs(mock_serve, api_key="my-secret", websocket_auth=self._refuse)
+        connection = MagicMock()
+        connection.respond.return_value = (401, [], b"Unauthorized\n")
+        request = Request("/", {"Authorization": "Bearer my-secret"})
+        self.assertEqual(kwargs["process_request"](connection, request)[0], 401)
+
+    @patch("whisper_live.server.serve")
+    def test_websocket_auth_alone_does_not_admit_a_connection(self, mock_serve):
+        def admit(connection, request):
+            return None
+
+        kwargs = self._serve_kwargs(mock_serve, api_key="my-secret", websocket_auth=admit)
+        connection = MagicMock()
+        connection.respond.return_value = (401, [], b"Unauthorized\n")
+        request = Request("/", {"Authorization": "Bearer wrong"})
+        self.assertEqual(kwargs["process_request"](connection, request)[0], 401)
+
+    @patch("whisper_live.server.serve")
+    def test_both_checks_passing_admits_the_connection(self, mock_serve):
+        def admit(connection, request):
+            return None
+
+        kwargs = self._serve_kwargs(mock_serve, api_key="my-secret", websocket_auth=admit)
+        request = Request("/", {"Authorization": "Bearer my-secret"})
+        self.assertIsNone(kwargs["process_request"](MagicMock(), request))
 
 
 def _make_transcription_info(language="en", language_probability=0.97, duration=1.0):

--- a/whisper_live/backend/base.py
+++ b/whisper_live/backend/base.py
@@ -81,6 +81,12 @@ class ServeClientBase(object):
         # WhisperLive's core code.
         self.segment_post_processor = None
 
+        # Optional pre-processing callable for incoming audio.
+        # If set, called with (frame_np, sample_rate) and must return a numpy
+        # array of samples. Applied by the server before VAD and add_frames,
+        # so external projects can run noise reduction on live audio.
+        self.audio_preprocessor = None
+
         # threading
         self.lock = threading.Lock()
         self.frames_ready = threading.Event()

--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -21,6 +21,7 @@ class Client:
     """
     INSTANCES = {}
     END_OF_AUDIO = "END_OF_AUDIO"
+    NORMAL_CLOSURE = 1000
 
     def __init__(
         self,
@@ -47,6 +48,7 @@ class Client:
         hotwords=None,
         enable_diarization=False,
         max_speakers=10,
+        known_speakers=None,
         word_timestamps=False,
         max_retries=0,
         retry_delay=5,
@@ -81,6 +83,13 @@ class Client:
             display_segments (int, optional): Number of recent transcript segments to display, and the maximum lines printed. Defaults to 4.
             initial_prompt (str, optional): Optional text to provide context to the model (e.g. domain vocabulary or names). Default is None.
             vad_parameters (dict, optional): Optional voice-activity-detection parameters passed to the server backend. Default is None.
+            known_speakers (list, optional): Reference clips to enroll in the server's diarizer at connection
+                time, as dicts of ``{"name": str, "audio_base64": str}`` where the audio is base64-encoded WAV
+                bytes. Default is None.
+            max_retries (int, optional): Number of reconnect attempts after an unexpected close. A close this
+                client asked for, a normal close after the server sent DISCONNECT, and a server error are not
+                retried. Default is 0.
+            retry_delay (int, optional): Seconds to wait before each reconnect attempt. Default is 5.
         """
         self.recording = False
         self.task = "transcribe"
@@ -120,10 +129,13 @@ class Client:
         self.hotwords = hotwords
         self.enable_diarization = enable_diarization
         self.max_speakers = max_speakers
+        self.known_speakers = known_speakers or []
         self.word_timestamps = word_timestamps
         self.max_retries = max_retries
         self.retry_delay = retry_delay
         self._retry_count = 0
+        self._client_initiated_close = False
+        self._server_disconnect = False
         self.audio_bytes = None
 
         if host is not None and port is not None:
@@ -149,6 +161,7 @@ class Client:
 
     def _create_websocket(self):
         """Creates a new WebSocketApp instance."""
+        self._server_disconnect = False
         self.client_socket = websocket.WebSocketApp(
             self.socket_url,
             on_open=lambda ws: self.on_open(ws),
@@ -271,6 +284,7 @@ class Client:
         if "message" in message.keys() and message["message"] == "DISCONNECT":
             print("[INFO]: Server disconnected due to overtime.")
             self.recording = False
+            self._server_disconnect = True
 
         if "message" in message.keys() and message["message"] == "SERVER_READY":
             self.last_response_received = time.time()
@@ -298,12 +312,33 @@ class Client:
         self.server_error = True
         self.error_message = error
 
+    def _should_reconnect(self, close_status_code):
+        """Decide whether an ``on_close`` should be followed by a reconnect.
+
+        Only unexpected closes are retried. A close this client asked for, a
+        normal close after the server said ``DISCONNECT``, and a close following
+        a server error are all treated as final.
+
+        Args:
+            close_status_code (int or None): The websocket close code.
+
+        Returns:
+            bool: True if a reconnect attempt should be made.
+        """
+        if self.max_retries <= 0 or self._retry_count >= self.max_retries:
+            return False
+        if self.server_error or self._client_initiated_close:
+            return False
+        if self._server_disconnect and close_status_code == self.NORMAL_CLOSURE:
+            return False
+        return True
+
     def on_close(self, ws, close_status_code, close_msg):
         print(f"[INFO]: Websocket connection closed: {close_status_code}: {close_msg}")
         self.recording = False
         self.waiting = False
 
-        if self.max_retries > 0 and self._retry_count < self.max_retries and not self.server_error:
+        if self._should_reconnect(close_status_code):
             self._retry_count += 1
             print(f"[INFO]: Reconnecting ({self._retry_count}/{self.max_retries}) in {self.retry_delay}s...")
             time.sleep(self.retry_delay)
@@ -341,6 +376,7 @@ class Client:
                     "hotwords": self.hotwords,
                     "enable_diarization": self.enable_diarization,
                     "max_speakers": self.max_speakers,
+                    "known_speakers": self.known_speakers,
                     "word_timestamps": self.word_timestamps,
                     "initial_prompt": self.initial_prompt,
                     "vad_parameters": self.vad_parameters,
@@ -359,6 +395,8 @@ class Client:
             Exception: If the WebSocket fails to send the packet.
 
         """
+        if message == Client.END_OF_AUDIO.encode("utf-8"):
+            self._client_initiated_close = True
         self.client_socket.send(message, websocket.ABNF.OPCODE_BINARY)
 
     def close_websocket(self):
@@ -369,6 +407,7 @@ class Client:
         closing the connection, it joins the WebSocket thread to ensure proper termination.
 
         """
+        self._client_initiated_close = True
         try:
             self.client_socket.close()
         except Exception as e:

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -47,6 +47,28 @@ STOCK_MODEL_SIZES = frozenset({
 # REST routes that stay reachable without an API key.
 API_KEY_EXEMPT_PATHS = frozenset({"/docs", "/redoc", "/openapi.json", "/health"})
 
+# Subprotocol a browser offers as `new WebSocket(url, ["bearer", token])`.
+BEARER_SUBPROTOCOL = "bearer"
+
+
+def _select_bearer_subprotocol(connection, subprotocols):
+    """Echo the bearer marker, never the token beside it.
+
+    Chrome closes the socket when the 101 omits a subprotocol it offered.
+    """
+    if BEARER_SUBPROTOCOL in subprotocols:
+        return BEARER_SUBPROTOCOL
+    return None
+
+
+def _all_websocket_checks(checks, connection, request):
+    """Run every handshake check and return the first refusal."""
+    for check in checks:
+        response = check(connection, request)
+        if response is not None:
+            return response
+    return None
+
 
 def _websocket_auth(api_key, connection, request):
     auth = request.headers.get("Authorization", "")
@@ -935,6 +957,7 @@ class TranscriptionServer:
             raw_pcm_input=False,
             metrics_port: int = 0,
             api_key: Optional[str] = None,
+            websocket_auth=None,
             rate_limit_rpm: int = 0,
             segment_post_processor=None,
             audio_preprocessor=None,
@@ -963,6 +986,11 @@ class TranscriptionServer:
                 ``(frame_np, sample_rate) -> np.ndarray`` applied to every audio
                 frame before VAD and before it reaches the backend. Useful for
                 plugging in noise reduction on live audio. Defaults to None.
+            websocket_auth (callable, optional): A callable
+                ``(connection, request) -> Response | None`` passed to the
+                websocket server as ``process_request``. Returning a response
+                refuses the handshake. When ``api_key`` is also set both checks
+                must pass. Defaults to None.
             default_model (str): The faster-whisper model the REST endpoint loads
                 when the request's ``model`` field is ``whisper-1`` or absent.
                 Defaults to "small". A custom model passed with
@@ -1038,9 +1066,16 @@ class TranscriptionServer:
             logging.info(f"✅ OpenAI-Compatible API started on http://0.0.0.0:{rest_port}")
 
         # Original WebSocket server (always supported)
-        extra_ws_kwargs = {}
+        extra_ws_kwargs = {"select_subprotocol": _select_bearer_subprotocol}
+        handshake_checks = []
         if api_key:
-            extra_ws_kwargs["process_request"] = functools.partial(_websocket_auth, api_key)
+            handshake_checks.append(functools.partial(_websocket_auth, api_key))
+        if websocket_auth is not None:
+            handshake_checks.append(websocket_auth)
+        if handshake_checks:
+            extra_ws_kwargs["process_request"] = functools.partial(
+                _all_websocket_checks, handshake_checks
+            )
 
         with serve(
             functools.partial(

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -1,3 +1,5 @@
+import base64
+import binascii
 import os
 import time
 import threading
@@ -29,6 +31,21 @@ from whisper_live.vad import VoiceActivityDetector
 from whisper_live.backend.base import ServeClientBase
 
 logging.basicConfig(level=logging.INFO)
+
+# Model name OpenAI clients send when they do not name a whisper size.
+OPENAI_MODEL_ALIAS = "whisper-1"
+
+# faster-whisper model sizes that can be passed straight to WhisperModel().
+STOCK_MODEL_SIZES = frozenset({
+    "tiny", "tiny.en",
+    "base", "base.en",
+    "small", "small.en",
+    "medium", "medium.en",
+    "large-v2", "large-v3", "large-v3-turbo",
+})
+
+# REST routes that stay reachable without an API key.
+API_KEY_EXEMPT_PATHS = frozenset({"/docs", "/redoc", "/openapi.json", "/health"})
 
 
 def _websocket_auth(api_key, connection, request):
@@ -193,10 +210,15 @@ class TranscriptionServer:
         self.raw_pcm_input = False
         self.audio_formats = {}
         self.segment_post_processor = None
+        self.audio_preprocessor = None
+        self.default_model = "small"
+        self.rest_models = {}
+        self.rest_models_lock = threading.Lock()
 
     def initialize_client(
         self, websocket, options, faster_whisper_custom_model_path,
         whisper_tensorrt_path, trt_multilingual, trt_py_session=False,
+        audio_preprocessor=None,
     ):
         client: Optional[ServeClientBase] = None
 
@@ -337,6 +359,8 @@ class TranscriptionServer:
         if self.segment_post_processor is not None:
             client.segment_post_processor = self.segment_post_processor
 
+        client.audio_preprocessor = audio_preprocessor or self.audio_preprocessor
+
         if translation_client:
             client.translation_client = translation_client
             client.translation_thread = translation_thread
@@ -346,21 +370,59 @@ class TranscriptionServer:
     def _create_diarizer(self, options):
         """Create a SpeakerDiarizer if the client requested diarization.
 
+        Diarization is created when the handshake sets ``enable_diarization`` or
+        carries ``known_speakers``. Each known speaker is a dict with a ``name``
+        and base64-encoded reference audio under ``audio_base64``.
+
         Returns:
             SpeakerDiarizer or None
         """
-        if not options.get("enable_diarization", False):
+        known_speakers = options.get("known_speakers") or []
+        if not options.get("enable_diarization", False) and not known_speakers:
             return None
         try:
             from whisper_live.diarization import SpeakerDiarizer
-            return SpeakerDiarizer(
+            diarizer = SpeakerDiarizer(
                 similarity_threshold=options.get("diarization_threshold", 0.55),
-                max_speakers=options.get("max_speakers", 10),
+                max_speakers=max(options.get("max_speakers", 10), len(known_speakers)),
                 hf_token=options.get("hf_token"),
             )
         except ImportError:
             logging.warning("pyannote.audio not installed; diarization disabled")
             return None
+        self._enroll_known_speakers(diarizer, known_speakers)
+        return diarizer
+
+    @staticmethod
+    def _enroll_known_speakers(diarizer, known_speakers):
+        """Enroll base64-encoded reference clips from the handshake into a diarizer.
+
+        Args:
+            diarizer (SpeakerDiarizer): The diarizer to enroll into.
+            known_speakers (list): Dicts with ``name`` and ``audio_base64`` keys.
+        """
+        from whisper_live.diarization import load_audio
+
+        for speaker in known_speakers:
+            name = speaker.get("name")
+            audio_base64 = speaker.get("audio_base64")
+            if not name or not audio_base64:
+                logging.warning("Skipping known speaker without a name or audio_base64")
+                continue
+            reference_path = None
+            try:
+                with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
+                    tmp.write(base64.b64decode(audio_base64))
+                    reference_path = tmp.name
+                if diarizer.enroll_speaker(name, load_audio(reference_path)):
+                    logging.info(f"Enrolled known speaker '{name}'")
+                else:
+                    logging.warning(f"Reference audio for known speaker '{name}' is too short")
+            except (binascii.Error, ValueError) as e:
+                logging.error(f"Failed to enroll known speaker '{name}': {e}")
+            finally:
+                if reference_path and os.path.exists(reference_path):
+                    os.unlink(reference_path)
 
     def get_audio_from_websocket(self, websocket):
         """
@@ -425,6 +487,13 @@ class TranscriptionServer:
                 client.set_eos(True)
             return False
 
+        preprocessor = getattr(client, "audio_preprocessor", None)
+        if preprocessor is not None:
+            try:
+                frame_np = preprocessor(frame_np, self.RATE)
+            except Exception as e:
+                logging.error(f"audio_preprocessor failed: {e}")
+
         if self.backend.is_tensorrt():
             voice_active = self.voice_activity(websocket, frame_np)
             if voice_active:
@@ -487,10 +556,55 @@ class TranscriptionServer:
             wl_metrics.track_connection_closed()
             del websocket
 
+    def _resolve_rest_model(self, requested_model):
+        """Map the REST ``model`` form field onto a faster-whisper model name.
+
+        Accepts a stock size name, a local path or a HuggingFace repo id. Anything
+        else, including the ``whisper-1`` alias and an absent field, falls back to
+        the server's default model.
+
+        Args:
+            requested_model (str or None): The ``model`` value sent by the client.
+
+        Returns:
+            str: The model name or path to load.
+        """
+        if not requested_model or requested_model == OPENAI_MODEL_ALIAS:
+            return self.default_model
+        if requested_model in STOCK_MODEL_SIZES:
+            return requested_model
+        if os.path.exists(requested_model) or "/" in requested_model:
+            return requested_model
+        logging.warning(f"Unknown model '{requested_model}'; using '{self.default_model}' instead.")
+        return self.default_model
+
+    def _get_rest_model(self, model_name):
+        """Return a cached ``WhisperModel`` for ``model_name``, loading it once.
+
+        Args:
+            model_name (str): Model name or path accepted by faster-whisper.
+
+        Returns:
+            WhisperModel: The shared model instance for that name.
+        """
+        with self.rest_models_lock:
+            transcriber = self.rest_models.get(model_name)
+            if transcriber is None:
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+                compute_type = "float16" if device == "cuda" else "int8"
+                logging.info(f"Loading REST model '{model_name}' on {device}")
+                transcriber = WhisperModel(model_name, device=device, compute_type=compute_type)
+                self.rest_models[model_name] = transcriber
+            return transcriber
+
     def _stream_transcription(self, file, language, prompt, temperature,
                               timestamp_granularities,
-                              faster_whisper_custom_model_path):
-        """Return a StreamingResponse that yields SSE events per segment."""
+                              requested_model=None):
+        """Return a StreamingResponse that yields SSE events per segment.
+
+        The first event carries the detected language and its probability, then
+        one event per segment, then ``[DONE]``.
+        """
 
         async def _sse_generator():
             tmp_path = None
@@ -500,10 +614,7 @@ class TranscriptionServer:
                     shutil.copyfileobj(file.file, tmp)
                     tmp_path = tmp.name
 
-                device = "cuda" if torch.cuda.is_available() else "cpu"
-                compute_type = "float16" if device == "cuda" else "int8"
-                model_name = faster_whisper_custom_model_path or "small"
-                transcriber = WhisperModel(model_name, device=device, compute_type=compute_type)
+                transcriber = self._get_rest_model(self._resolve_rest_model(requested_model))
                 segments, info = transcriber.transcribe(
                     tmp_path,
                     language=language,
@@ -512,6 +623,13 @@ class TranscriptionServer:
                     vad_filter=False,
                     word_timestamps=(timestamp_granularities and "word" in timestamp_granularities),
                 )
+
+                metadata = {
+                    "type": "metadata",
+                    "language": info.language,
+                    "language_probability": info.language_probability,
+                }
+                yield f"data: {json.dumps(metadata)}\n\n"
 
                 for seg in segments:
                     seg_dict = {
@@ -597,6 +715,205 @@ class TranscriptionServer:
                 labels[index] = speaker
         return labels
 
+    def build_rest_app(self, backend, faster_whisper_custom_model_path=None,
+                       whisper_tensorrt_path=None, cors_origins=None,
+                       api_key=None, rate_limit_rpm=0):
+        """Build the OpenAI-compatible REST app served alongside the WebSocket server.
+
+        Args:
+            backend (str): Backend name reported by ``/health``.
+            faster_whisper_custom_model_path (str, optional): Custom model reported by ``/health``.
+            whisper_tensorrt_path (str, optional): TensorRT model reported by ``/health``.
+            cors_origins (str, optional): Comma-separated list of allowed CORS origins.
+            api_key (str, optional): When set, every route except ``API_KEY_EXEMPT_PATHS``
+                requires an ``Authorization: Bearer`` header carrying this key.
+            rate_limit_rpm (int): Requests per minute per client IP. 0 disables the limit.
+
+        Returns:
+            FastAPI: The configured app.
+        """
+        app = FastAPI(title="WhisperLive OpenAI-Compatible API")
+        origins = [o.strip() for o in cors_origins.split(',')] if cors_origins else []
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=origins,
+            allow_credentials=True,
+            allow_methods=["*"],  # Allows all methods (GET, POST, etc.)
+            allow_headers=["*"],  # Allows all headers
+        )
+
+        # Optional API key authentication
+        if api_key:
+            @app.middleware("http")
+            async def _check_api_key(request: Request, call_next):
+                if request.url.path not in API_KEY_EXEMPT_PATHS:
+                    auth = request.headers.get("Authorization", "")
+                    if auth != f"Bearer {api_key}":
+                        return JSONResponse({"error": "Invalid or missing API key"}, status_code=401)
+                return await call_next(request)
+
+        # Optional rate limiting (requests per minute per client IP)
+        if rate_limit_rpm > 0:
+            _rate_lock = threading.Lock()
+            _rate_buckets: dict = {}  # ip -> deque of timestamps
+
+            @app.middleware("http")
+            async def _rate_limit(request: Request, call_next):
+                client_ip = request.client.host if request.client else "unknown"
+                now = time.time()
+                with _rate_lock:
+                    bucket = _rate_buckets.setdefault(client_ip, collections.deque())
+                    # Discard entries older than 60s
+                    while bucket and bucket[0] < now - 60:
+                        bucket.popleft()
+                    if len(bucket) >= rate_limit_rpm:
+                        return JSONResponse({"error": "Rate limit exceeded"}, status_code=429)
+                    bucket.append(now)
+                return await call_next(request)
+
+        health_model = faster_whisper_custom_model_path or whisper_tensorrt_path or self.default_model
+
+        @app.get("/health")
+        async def health():
+            """Report backend, model and client occupancy without requiring an API key."""
+            return {
+                "status": "ok",
+                "backend": backend,
+                "model": health_model,
+                "clients": len(self.client_manager.clients),
+                "max_clients": self.client_manager.max_clients,
+            }
+
+        @app.post("/v1/audio/transcriptions")
+        async def transcribe(
+            file: UploadFile,
+            model: str = Form(default="whisper-1"),
+            language: Optional[str] = Form(default=None),
+            prompt: Optional[str] = Form(default=None),
+            response_format: str = Form(default="json"),
+            temperature: float = Form(default=0.0),
+            timestamp_granularities: Optional[List[str]] = Form(default=None),
+            # Stubs for unsupported OpenAI params
+            chunking_strategy: Optional[str] = Form(default=None),
+            include: Optional[List[str]] = Form(default=None),
+            known_speaker_names: Optional[List[str]] = Form(default=None),
+            known_speaker_references: Optional[List[UploadFile]] = File(default=None),
+            stream: bool = Form(default=False),
+            hotwords: Optional[str] = Form(default=None),
+        ):
+            if stream:
+                return self._stream_transcription(
+                    file, language, prompt, temperature,
+                    timestamp_granularities,
+                    model,
+                )
+
+            ignored_params = []
+            if chunking_strategy:
+                ignored_params.append(f"chunking_strategy='{chunking_strategy}'")
+            if include:
+                ignored_params.append(f"include={include}")
+            if ignored_params:
+                logging.warning(f"Unsupported OpenAI params ignored: {', '.join(ignored_params)}")
+
+            supported_formats = ["json", "text", "srt", "verbose_json", "vtt"]
+            if response_format not in supported_formats:
+                wl_metrics.track_rest_request(endpoint="transcriptions", status=400)
+                return JSONResponse({"error": f"Unsupported response_format. Supported: {supported_formats}"}, status_code=400)
+
+            model_name = self._resolve_rest_model(model)
+
+            tmp_path = None
+            try:
+                suffix = os.path.splitext(file.filename)[1] or ".wav"
+                with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+                    shutil.copyfileobj(file.file, tmp)
+                    tmp_path = tmp.name
+
+                transcriber = self._get_rest_model(model_name)
+                segments, info = transcriber.transcribe(
+                    tmp_path,
+                    language=language,
+                    initial_prompt=prompt,
+                    temperature=temperature,
+                    vad_filter=False,
+                    word_timestamps=(timestamp_granularities and "word" in timestamp_granularities),
+                    hotwords=hotwords,
+                )
+                segments = list(segments)
+
+                text = " ".join([s.text.strip() for s in segments])
+
+                if response_format == "text":
+                    wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
+                    return PlainTextResponse(text)
+                elif response_format == "json":
+                    wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
+                    return {
+                        "text": text,
+                        "language": info.language,
+                        "language_probability": info.language_probability,
+                    }
+                elif response_format == "verbose_json":
+                    verbose = {
+                        "task": "transcribe",
+                        "language": info.language,
+                        "language_probability": info.language_probability,
+                        "duration": info.duration,
+                        "text": text,
+                        "segments": []
+                    }
+                    speaker_labels = {}
+                    try:
+                        rest_diarizer = await self._create_rest_diarizer(known_speaker_names, known_speaker_references)
+                    except ValueError as e:
+                        wl_metrics.track_rest_request(endpoint="transcriptions", status=400)
+                        return JSONResponse({"error": str(e)}, status_code=400)
+                    if rest_diarizer is not None:
+                        from whisper_live.diarization import load_audio
+                        audio_np = load_audio(tmp_path)
+                        speaker_labels = self._speaker_labels_for_segments(segments, audio_np, rest_diarizer)
+                    for index, seg in enumerate(segments):
+                        seg_dict = {
+                            "id": seg.id,
+                            "seek": seg.seek,
+                            "start": seg.start,
+                            "end": seg.end,
+                            "text": seg.text.strip(),
+                            "tokens": seg.tokens,
+                            "temperature": seg.temperature,
+                            "avg_logprob": seg.avg_logprob,
+                            "compression_ratio": seg.compression_ratio,
+                            "no_speech_prob": seg.no_speech_prob
+                        }
+                        if index in speaker_labels:
+                            seg_dict["speaker"] = speaker_labels[index]
+                        if timestamp_granularities and "word" in timestamp_granularities:
+                            seg_dict["words"] = [{"word": w.word, "start": w.start, "end": w.end, "probability": w.probability} for w in seg.words]
+                        verbose["segments"].append(seg_dict)
+                    wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
+                    return verbose
+                elif response_format in ["srt", "vtt"]:
+                    output = []
+                    for i, seg in enumerate(segments, 1):
+                        start = f"{int(seg.start // 3600):02}:{int((seg.start % 3600) // 60):02}:{seg.start % 60:06.3f}"
+                        end = f"{int(seg.end // 3600):02}:{int((seg.end % 3600) // 60):02}:{seg.end % 60:06.3f}"
+                        if response_format == "srt":
+                            output.append(f"{i}\n{start.replace('.', ',')} --> {end.replace('.', ',')}\n{seg.text.strip()}\n")
+                        else:  # vtt
+                            output.append(f"{start} --> {end}\n{seg.text.strip()}\n")
+                    wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
+                    return PlainTextResponse("\n".join(output))
+            except Exception as e:
+                wl_metrics.track_rest_request(endpoint="transcriptions", status=500)
+                wl_metrics.track_error("rest_transcription")
+                return JSONResponse({"error": str(e)}, status_code=500)
+            finally:
+                if tmp_path and os.path.exists(tmp_path):
+                    os.unlink(tmp_path)
+
+        return app
+
     def run(self,
             host,
             port=9090,
@@ -619,7 +936,9 @@ class TranscriptionServer:
             metrics_port: int = 0,
             api_key: Optional[str] = None,
             rate_limit_rpm: int = 0,
-            segment_post_processor=None):
+            segment_post_processor=None,
+            audio_preprocessor=None,
+            default_model: str = "small"):
         """
         Run the transcription server.
 
@@ -640,9 +959,19 @@ class TranscriptionServer:
                 Applied to every segment before sending to the client. Useful for
                 plugging in custom post-processing (e.g. formatting, redaction).
                 Defaults to None.
+            audio_preprocessor (callable, optional): A callable
+                ``(frame_np, sample_rate) -> np.ndarray`` applied to every audio
+                frame before VAD and before it reaches the backend. Useful for
+                plugging in noise reduction on live audio. Defaults to None.
+            default_model (str): The faster-whisper model the REST endpoint loads
+                when the request's ``model`` field is ``whisper-1`` or absent.
+                Defaults to "small". A custom model passed with
+                ``faster_whisper_custom_model_path`` takes precedence.
         """
         self.cache_path = cache_path
         self.raw_pcm_input = raw_pcm_input
+        self.audio_preprocessor = audio_preprocessor
+        self.default_model = faster_whisper_custom_model_path or default_model
 
         if max_clients < 1:
             raise ValueError(f"max_clients must be >= 1, got {max_clients}")
@@ -691,172 +1020,14 @@ class TranscriptionServer:
 
         # New OpenAI-compatible REST API (toggleable via enable_rest boolean)
         if enable_rest:
-            app = FastAPI(title="WhisperLive OpenAI-Compatible API")
-            origins = [o.strip() for o in cors_origins.split(',')] if cors_origins else []
-            app.add_middleware(
-                CORSMiddleware,
-                allow_origins=origins,
-                allow_credentials=True,
-                allow_methods=["*"],  # Allows all methods (GET, POST, etc.)
-                allow_headers=["*"],  # Allows all headers
+            app = self.build_rest_app(
+                backend,
+                faster_whisper_custom_model_path=faster_whisper_custom_model_path,
+                whisper_tensorrt_path=whisper_tensorrt_path,
+                cors_origins=cors_origins,
+                api_key=api_key,
+                rate_limit_rpm=rate_limit_rpm,
             )
-
-            # Optional API key authentication
-            if api_key:
-                @app.middleware("http")
-                async def _check_api_key(request: Request, call_next):
-                    auth = request.headers.get("Authorization", "")
-                    if auth != f"Bearer {api_key}":
-                        return JSONResponse({"error": "Invalid or missing API key"}, status_code=401)
-                    return await call_next(request)
-
-            # Optional rate limiting (requests per minute per client IP)
-            if rate_limit_rpm > 0:
-                _rate_lock = threading.Lock()
-                _rate_buckets: dict = {}  # ip -> deque of timestamps
-
-                @app.middleware("http")
-                async def _rate_limit(request: Request, call_next):
-                    client_ip = request.client.host if request.client else "unknown"
-                    now = time.time()
-                    with _rate_lock:
-                        bucket = _rate_buckets.setdefault(client_ip, collections.deque())
-                        # Discard entries older than 60s
-                        while bucket and bucket[0] < now - 60:
-                            bucket.popleft()
-                        if len(bucket) >= rate_limit_rpm:
-                            return JSONResponse({"error": "Rate limit exceeded"}, status_code=429)
-                        bucket.append(now)
-                    return await call_next(request)
-
-
-            @app.post("/v1/audio/transcriptions")
-            async def transcribe(
-                file: UploadFile,
-                model: str = Form(default="whisper-1"),
-                language: Optional[str] = Form(default=None),
-                prompt: Optional[str] = Form(default=None),
-                response_format: str = Form(default="json"),
-                temperature: float = Form(default=0.0),
-                timestamp_granularities: Optional[List[str]] = Form(default=None),
-                # Stubs for unsupported OpenAI params
-                chunking_strategy: Optional[str] = Form(default=None),
-                include: Optional[List[str]] = Form(default=None),
-                known_speaker_names: Optional[List[str]] = Form(default=None),
-                known_speaker_references: Optional[List[UploadFile]] = File(default=None),
-                stream: bool = Form(default=False),
-                hotwords: Optional[str] = Form(default=None),
-            ):
-                if stream:
-                    return self._stream_transcription(
-                        file, language, prompt, temperature,
-                        timestamp_granularities,
-                        faster_whisper_custom_model_path,
-                    )
-
-                ignored_params = []
-                if chunking_strategy:
-                    ignored_params.append(f"chunking_strategy='{chunking_strategy}'")
-                if include:
-                    ignored_params.append(f"include={include}")
-                if ignored_params:
-                    logging.warning(f"Unsupported OpenAI params ignored: {', '.join(ignored_params)}")
-
-                supported_formats = ["json", "text", "srt", "verbose_json", "vtt"]
-                if response_format not in supported_formats:
-                    wl_metrics.track_rest_request(endpoint="transcriptions", status=400)
-                    return JSONResponse({"error": f"Unsupported response_format. Supported: {supported_formats}"}, status_code=400)
-
-                if model != "whisper-1":
-                    logging.warning(f"Model '{model}' requested; using 'small' as fallback.")
-                model_name = faster_whisper_custom_model_path or "small"
-
-                tmp_path = None
-                try:
-                    suffix = os.path.splitext(file.filename)[1] or ".wav"
-                    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
-                        shutil.copyfileobj(file.file, tmp)
-                        tmp_path = tmp.name
-
-                    device = "cuda" if torch.cuda.is_available() else "cpu"
-                    compute_type = "float16" if device == "cuda" else "int8"
-
-                    transcriber = WhisperModel(model_name, device=device, compute_type=compute_type)
-                    segments, info = transcriber.transcribe(
-                        tmp_path,
-                        language=language,
-                        initial_prompt=prompt,
-                        temperature=temperature,
-                        vad_filter=False,
-                        word_timestamps=(timestamp_granularities and "word" in timestamp_granularities),
-                        hotwords=hotwords,
-                    )
-                    segments = list(segments)
-
-                    text = " ".join([s.text.strip() for s in segments])
-
-                    if response_format == "text":
-                        wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
-                        return PlainTextResponse(text)
-                    elif response_format == "json":
-                        wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
-                        return {"text": text}
-                    elif response_format == "verbose_json":
-                        verbose = {
-                            "task": "transcribe",
-                            "language": info.language,
-                            "duration": info.duration,
-                            "text": text,
-                            "segments": []
-                        }
-                        speaker_labels = {}
-                        try:
-                            rest_diarizer = await self._create_rest_diarizer(known_speaker_names, known_speaker_references)
-                        except ValueError as e:
-                            wl_metrics.track_rest_request(endpoint="transcriptions", status=400)
-                            return JSONResponse({"error": str(e)}, status_code=400)
-                        if rest_diarizer is not None:
-                            from whisper_live.diarization import load_audio
-                            audio_np = load_audio(tmp_path)
-                            speaker_labels = self._speaker_labels_for_segments(segments, audio_np, rest_diarizer)
-                        for index, seg in enumerate(segments):
-                            seg_dict = {
-                                "id": seg.id,
-                                "seek": seg.seek,
-                                "start": seg.start,
-                                "end": seg.end,
-                                "text": seg.text.strip(),
-                                "tokens": seg.tokens,
-                                "temperature": seg.temperature,
-                                "avg_logprob": seg.avg_logprob,
-                                "compression_ratio": seg.compression_ratio,
-                                "no_speech_prob": seg.no_speech_prob
-                            }
-                            if index in speaker_labels:
-                                seg_dict["speaker"] = speaker_labels[index]
-                            if timestamp_granularities and "word" in timestamp_granularities:
-                                seg_dict["words"] = [{"word": w.word, "start": w.start, "end": w.end, "probability": w.probability} for w in seg.words]
-                            verbose["segments"].append(seg_dict)
-                        wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
-                        return verbose
-                    elif response_format in ["srt", "vtt"]:
-                        output = []
-                        for i, seg in enumerate(segments, 1):
-                            start = f"{int(seg.start // 3600):02}:{int((seg.start % 3600) // 60):02}:{seg.start % 60:06.3f}"
-                            end = f"{int(seg.end // 3600):02}:{int((seg.end % 3600) // 60):02}:{seg.end % 60:06.3f}"
-                            if response_format == "srt":
-                                output.append(f"{i}\n{start.replace('.', ',')} --> {end.replace('.', ',')}\n{seg.text.strip()}\n")
-                            else:  # vtt
-                                output.append(f"{start} --> {end}\n{seg.text.strip()}\n")
-                        wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
-                        return PlainTextResponse("\n".join(output))
-                except Exception as e:
-                    wl_metrics.track_rest_request(endpoint="transcriptions", status=500)
-                    wl_metrics.track_error("rest_transcription")
-                    return JSONResponse({"error": str(e)}, status_code=500)
-                finally:
-                    if tmp_path and os.path.exists(tmp_path):
-                        os.unlink(tmp_path)
 
             threading.Thread(
                 target=uvicorn.run,


### PR DESCRIPTION
rest api, client and websocket auth fixes, independent of #535. tests in `tests/test_server_extended.py` and `tests/test_client_extended.py`.

- client reconnects only on unexpected closes, `known_speakers` handshake option
- `GET /health` on the rest app
- `--default_model` and per-request `model` field, loaded models cached per name
- docs and health paths exempt from the api key middleware
- `language` and `language_probability` in json responses and as an sse metadata event
- `audio_preprocessor` hook, applied before VAD
- `known_speakers` over the websocket handshake
- `build_rest_app()` split out of `run()` for tests
- `websocket_auth` hook for the websocket handshake, bearer token accepted as a subprotocol
