### PR TITLE
fix(backend): ServeClientBase.transcribe_audio stub omits the argument its own call site passes

### DIFF
--- a/whisper_live/backend/base.py
+++ b/whisper_live/backend/base.py
@@ -136,7 +136,7 @@ class ServeClientBase(object):
                 wl_metrics.track_error("transcription")
                 time.sleep(0.01)
 
-    def transcribe_audio(self):
+    def transcribe_audio(self, input_sample):
         raise NotImplementedError
 
     def handle_transcription_output(self, result, duration):


### PR DESCRIPTION
## Problem

`ServeClientBase.transcribe_audio` is the abstract hook every backend implements,
but its declared signature takes no arguments
(`whisper_live/backend/base.py:139`):

```python
def transcribe_audio(self):
    raise NotImplementedError
```

The base class's own call site passes one (`base.py:124`, inside
`speech_to_text`):

```python
result = self.transcribe_audio(input_sample)
```

So the declared contract and the only call to it disagree. Every implementation
sides with the call site, not the stub:

| definition | signature |
|---|---|
| `whisper_live/backend/base.py:139` | `transcribe_audio(self)` ← the odd one out |
| `whisper_live/backend/faster_whisper_backend.py:196` | `transcribe_audio(self, input_sample)` |
| `whisper_live/backend/openvino_backend.py:110` | `transcribe_audio(self, input_sample)` |
| `whisper_live/backend/trt_backend.py:138` | `transcribe_audio(self, input_bytes)` |
| `tests/test_base_backend.py:20` | `transcribe_audio(self, input_sample)` |
| `tests/test_diarization.py:123` | `transcribe_audio(self, input_sample)` |

The sibling stub declared three lines below gets this right, which is what the
correct shape looks like:

```python
def handle_transcription_output(self, result, duration):   # base.py:142
    raise NotImplementedError
```

and its call site is `self.handle_transcription_output(result, duration)`
(`base.py:132`).

## Why it matters

A new backend written against the documented stub signature — `def
transcribe_audio(self)` — raises `TypeError: transcribe_audio() takes 1
positional argument but 2 were given` on the first audio chunk. That call is
inside the `try/except Exception` at `base.py:134`, so it does not surface as a
crash: it is swallowed into

```
[ERROR]: Failed to transcribe audio chunk: ...
```

and the `while` loop retries forever, which makes a plain arity mismatch look
like a transcription-model failure.

## Fix

One line — give the stub the parameter its call site already passes:

```diff
-    def transcribe_audio(self):
+    def transcribe_audio(self, input_sample):
         raise NotImplementedError
```

No behaviour changes: the body still raises `NotImplementedError`, and every
existing override already accepts one positional argument, so none of them need
touching.

## Verification

Signatures collected from the real files with `ast`, and the call site replayed
against the stub with `inspect.Signature.bind`:

```
--- bind the base-class call site against the base-class signature ---
  declared: transcribe_audio(self)
  call site base.py:124 -> self.transcribe_audio(input_sample)
  UNPATCHED bind -> TypeError: too many positional arguments
  PATCHED  bind -> OK
```

## Scope

Only the stub signature. `trt_backend.py` names its parameter `input_bytes`
rather than `input_sample`; since the call is positional that is harmless, and
renaming it is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
