### PR TITLE
rest health, model selection, language metadata, audio preprocessor hook

### DIFF
--- a/run_server.py
+++ b/run_server.py
@@ -104,6 +104,13 @@ if __name__ == "__main__":
              'Clients must send "Authorization: Bearer <key>" header or "?token=<key>" query parameter.'
     )
     parser.add_argument(
+        '--default_model',
+        type=str,
+        default='small',
+        help='faster-whisper model the REST endpoint loads when the request does not name one '
+             '(default: small). Overridden by --faster_whisper_custom_model_path.'
+    )
+    parser.add_argument(
         '--rate_limit_rpm',
         type=int,
         default=0,
@@ -142,4 +149,5 @@ if __name__ == "__main__":
         metrics_port=args.metrics_port,
         api_key=args.api_key,
         rate_limit_rpm=args.rate_limit_rpm,
+        default_model=args.default_model,
     )

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -752,6 +752,482 @@ class TestWebSocketAuth(unittest.TestCase):
         self.assertEqual(result[0], 401)
 
 
+def _make_transcription_info(language="en", language_probability=0.97, duration=1.0):
+    info = MagicMock()
+    info.language = language
+    info.language_probability = language_probability
+    info.duration = duration
+    return info
+
+
+def _make_segment(index=0, text=" hello ", start=0.0, end=1.0):
+    seg = MagicMock()
+    seg.id = index
+    seg.seek = 0
+    seg.start = start
+    seg.end = end
+    seg.text = text
+    seg.tokens = []
+    seg.temperature = 0.0
+    seg.avg_logprob = -0.1
+    seg.compression_ratio = 1.2
+    seg.no_speech_prob = 0.01
+    seg.words = []
+    return seg
+
+
+class TestHealthEndpoint(unittest.TestCase):
+    """Tests for the REST /health route built by build_rest_app()."""
+
+    def _make_client(self, api_key=None, **kwargs):
+        from fastapi.testclient import TestClient
+
+        self.server = TranscriptionServer()
+        self.server.client_manager = ClientManager(max_clients=3, max_connection_time=60)
+        app = self.server.build_rest_app("faster_whisper", api_key=api_key, **kwargs)
+        return TestClient(app)
+
+    def test_health_reports_backend_model_and_clients(self):
+        client = self._make_client()
+        self.server.client_manager.add_client(MagicMock(), MagicMock())
+        resp = client.get("/health")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp.json(),
+            {
+                "status": "ok",
+                "backend": "faster_whisper",
+                "model": "small",
+                "clients": 1,
+                "max_clients": 3,
+            },
+        )
+
+    def test_health_reports_default_model_override(self):
+        from fastapi.testclient import TestClient
+
+        server = TranscriptionServer()
+        server.default_model = "large-v3"
+        server.client_manager = ClientManager(max_clients=2, max_connection_time=60)
+        client = TestClient(server.build_rest_app("faster_whisper"))
+        self.assertEqual(client.get("/health").json()["model"], "large-v3")
+
+    def test_health_reports_custom_model_path(self):
+        client = self._make_client(faster_whisper_custom_model_path="org/custom-model")
+        self.assertEqual(client.get("/health").json()["model"], "org/custom-model")
+
+    def test_health_needs_no_api_key(self):
+        client = self._make_client(api_key="test-secret")
+        resp = client.get("/health")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["status"], "ok")
+
+    def test_health_works_with_api_key_header(self):
+        client = self._make_client(api_key="test-secret")
+        resp = client.get("/health", headers={"Authorization": "Bearer test-secret"})
+        self.assertEqual(resp.status_code, 200)
+
+    def test_docs_routes_need_no_api_key(self):
+        client = self._make_client(api_key="test-secret")
+        for path in ("/docs", "/redoc", "/openapi.json"):
+            with self.subTest(path=path):
+                self.assertEqual(client.get(path).status_code, 200)
+
+    def test_transcriptions_still_requires_api_key(self):
+        import io
+
+        client = self._make_client(api_key="test-secret")
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+        )
+        self.assertEqual(resp.status_code, 401)
+
+
+class TestRestModelSelection(unittest.TestCase):
+    """Tests for _resolve_rest_model() and the REST model cache."""
+
+    def setUp(self):
+        self.server = TranscriptionServer()
+
+    def test_whisper_1_alias_uses_default(self):
+        self.assertEqual(self.server._resolve_rest_model("whisper-1"), "small")
+
+    def test_missing_model_uses_default(self):
+        self.assertEqual(self.server._resolve_rest_model(None), "small")
+        self.assertEqual(self.server._resolve_rest_model(""), "small")
+
+    def test_default_model_is_configurable(self):
+        self.server.default_model = "medium"
+        self.assertEqual(self.server._resolve_rest_model("whisper-1"), "medium")
+
+    def test_stock_sizes_are_honoured(self):
+        for name in ("tiny", "base", "small", "medium", "large-v2", "large-v3", "large-v3-turbo"):
+            with self.subTest(name=name):
+                self.assertEqual(self.server._resolve_rest_model(name), name)
+
+    def test_english_only_variants_are_honoured(self):
+        for name in ("tiny.en", "base.en", "small.en", "medium.en"):
+            with self.subTest(name=name):
+                self.assertEqual(self.server._resolve_rest_model(name), name)
+
+    def test_hf_repo_id_is_honoured(self):
+        self.assertEqual(self.server._resolve_rest_model("deepdml/faster-whisper-x"), "deepdml/faster-whisper-x")
+
+    def test_local_path_is_honoured(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as model_dir:
+            self.assertEqual(self.server._resolve_rest_model(model_dir), model_dir)
+
+    def test_unknown_name_falls_back_to_default(self):
+        self.server.default_model = "base"
+        self.assertEqual(self.server._resolve_rest_model("gpt-4o-transcribe"), "base")
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_model_is_loaded_once_per_name(self, mock_model_cls):
+        first = self.server._get_rest_model("small")
+        second = self.server._get_rest_model("small")
+        self.assertIs(first, second)
+        mock_model_cls.assert_called_once()
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_different_names_load_separate_models(self, mock_model_cls):
+        mock_model_cls.side_effect = [MagicMock(name="small"), MagicMock(name="medium")]
+        small = self.server._get_rest_model("small")
+        medium = self.server._get_rest_model("medium")
+        self.assertIsNot(small, medium)
+        self.assertEqual(mock_model_cls.call_count, 2)
+        self.assertEqual(set(self.server.rest_models), {"small", "medium"})
+
+    @patch("whisper_live.server.serve")
+    def test_run_threads_default_model(self, mock_serve):
+        server = TranscriptionServer()
+        server.run("0.0.0.0", backend="faster_whisper", default_model="large-v3")
+        self.assertEqual(server.default_model, "large-v3")
+
+    @patch("whisper_live.server.serve")
+    def test_custom_model_path_outranks_default_model(self, mock_serve):
+        server = TranscriptionServer()
+        server.run(
+            "0.0.0.0",
+            backend="faster_whisper",
+            faster_whisper_custom_model_path="org/custom-model",
+            default_model="large-v3",
+        )
+        self.assertEqual(server.default_model, "org/custom-model")
+
+
+class TestRestTranscribeModelAndLanguage(unittest.TestCase):
+    """Tests that the REST endpoint honours `model` and reports language."""
+
+    def setUp(self):
+        self.server = TranscriptionServer()
+        self.server.client_manager = ClientManager(max_clients=2, max_connection_time=60)
+
+    def _post(self, mock_model_cls, **fields):
+        import io
+        from fastapi.testclient import TestClient
+
+        transcriber = MagicMock()
+        transcriber.transcribe.return_value = (iter([_make_segment()]), _make_transcription_info())
+        mock_model_cls.return_value = transcriber
+        self.transcriber = transcriber
+
+        client = TestClient(self.server.build_rest_app("faster_whisper"))
+        return client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+            data=fields,
+        )
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_stock_model_name_is_loaded(self, mock_model_cls):
+        resp = self._post(mock_model_cls, model="medium")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(mock_model_cls.call_args[0][0], "medium")
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_whisper_1_loads_default_model(self, mock_model_cls):
+        self.server.default_model = "base"
+        resp = self._post(mock_model_cls, model="whisper-1")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(mock_model_cls.call_args[0][0], "base")
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_repeated_requests_reuse_cached_model(self, mock_model_cls):
+        import io
+        from fastapi.testclient import TestClient
+
+        transcriber = MagicMock()
+        transcriber.transcribe.side_effect = lambda *a, **k: (
+            iter([_make_segment()]), _make_transcription_info()
+        )
+        mock_model_cls.return_value = transcriber
+
+        client = TestClient(self.server.build_rest_app("faster_whisper"))
+        for _ in range(3):
+            resp = client.post(
+                "/v1/audio/transcriptions",
+                files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+                data={"model": "small"},
+            )
+            self.assertEqual(resp.status_code, 200)
+        mock_model_cls.assert_called_once()
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_json_response_includes_language(self, mock_model_cls):
+        resp = self._post(mock_model_cls, response_format="json")
+        body = resp.json()
+        self.assertEqual(body["text"], "hello")
+        self.assertEqual(body["language"], "en")
+        self.assertAlmostEqual(body["language_probability"], 0.97)
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_verbose_json_includes_language_probability(self, mock_model_cls):
+        resp = self._post(mock_model_cls, response_format="verbose_json")
+        body = resp.json()
+        self.assertEqual(body["language"], "en")
+        self.assertAlmostEqual(body["language_probability"], 0.97)
+
+
+class TestStreamLanguageEvent(unittest.TestCase):
+    """The SSE stream must announce the detected language before any segment."""
+
+    def _stream(self, mock_model_cls, language_probability=0.91):
+        import io
+        from fastapi.testclient import TestClient
+
+        transcriber = MagicMock()
+        transcriber.transcribe.return_value = (
+            iter([_make_segment(text=" hello world ")]),
+            _make_transcription_info(language="de", language_probability=language_probability),
+        )
+        mock_model_cls.return_value = transcriber
+
+        server = TranscriptionServer()
+        server.client_manager = ClientManager(max_clients=2, max_connection_time=60)
+        client = TestClient(server.build_rest_app("faster_whisper"))
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+            data={"stream": "true"},
+        )
+        events = [
+            json.loads(line.removeprefix("data: "))
+            for line in resp.text.split("\n")
+            if line.startswith("data: ") and "[DONE]" not in line
+        ]
+        return events
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_first_event_carries_language(self, mock_model_cls):
+        events = self._stream(mock_model_cls)
+        self.assertEqual(events[0]["language"], "de")
+        self.assertAlmostEqual(events[0]["language_probability"], 0.91)
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_language_event_precedes_segments(self, mock_model_cls):
+        events = self._stream(mock_model_cls)
+        self.assertNotIn("text", events[0])
+        self.assertEqual(events[1]["text"], "hello world")
+
+    @patch("whisper_live.server.WhisperModel")
+    def test_stream_honours_model_field(self, mock_model_cls):
+        import io
+        from fastapi.testclient import TestClient
+
+        transcriber = MagicMock()
+        transcriber.transcribe.return_value = (iter([]), _make_transcription_info())
+        mock_model_cls.return_value = transcriber
+
+        server = TranscriptionServer()
+        server.client_manager = ClientManager(max_clients=2, max_connection_time=60)
+        client = TestClient(server.build_rest_app("faster_whisper"))
+        client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.wav", io.BytesIO(b"\x00" * 100), "audio/wav")},
+            data={"stream": "true", "model": "large-v3"},
+        )
+        self.assertEqual(mock_model_cls.call_args[0][0], "large-v3")
+
+
+class TestAudioPreprocessor(unittest.TestCase):
+    """Tests for the optional audio_preprocessor hook."""
+
+    def setUp(self):
+        self.server = TranscriptionServer()
+        self.server.backend = BackendType.FASTER_WHISPER
+        self.server.client_manager = ClientManager(max_clients=2, max_connection_time=60)
+
+    def _add_client(self, preprocessor):
+        import numpy as np
+
+        ws = MagicMock()
+        ws.recv.return_value = np.array([0.1, 0.2, 0.3], dtype=np.float32).tobytes()
+        client = MagicMock()
+        client.audio_preprocessor = preprocessor
+        self.server.client_manager.add_client(ws, client)
+        return ws, client
+
+    def test_preprocessor_output_reaches_add_frames(self):
+        import numpy as np
+
+        gained = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        ws, client = self._add_client(lambda frame, rate: gained)
+        self.assertTrue(self.server.process_audio_frames(ws))
+        np.testing.assert_array_equal(client.add_frames.call_args[0][0], gained)
+
+    def test_preprocessor_receives_frame_and_sample_rate(self):
+        import numpy as np
+
+        seen = {}
+
+        def preprocessor(frame, sample_rate):
+            seen["frame"] = frame
+            seen["sample_rate"] = sample_rate
+            return frame
+
+        ws, _ = self._add_client(preprocessor)
+        self.server.process_audio_frames(ws)
+        self.assertEqual(seen["sample_rate"], TranscriptionServer.RATE)
+        np.testing.assert_allclose(seen["frame"], [0.1, 0.2, 0.3], rtol=1e-6)
+
+    def test_no_preprocessor_leaves_frame_untouched(self):
+        import numpy as np
+
+        ws, client = self._add_client(None)
+        self.server.process_audio_frames(ws)
+        np.testing.assert_allclose(client.add_frames.call_args[0][0], [0.1, 0.2, 0.3], rtol=1e-6)
+
+    def test_failing_preprocessor_does_not_break_the_stream(self):
+        import numpy as np
+
+        def preprocessor(frame, sample_rate):
+            raise RuntimeError("denoiser exploded")
+
+        ws, client = self._add_client(preprocessor)
+        self.assertTrue(self.server.process_audio_frames(ws))
+        np.testing.assert_allclose(client.add_frames.call_args[0][0], [0.1, 0.2, 0.3], rtol=1e-6)
+
+    def test_preprocessor_runs_before_vad_for_tensorrt(self):
+        import numpy as np
+
+        self.server.backend = BackendType.TENSORRT
+        self.server.use_vad = True
+        denoised = np.array([0.9, 0.9, 0.9], dtype=np.float32)
+        ws, client = self._add_client(lambda frame, rate: denoised)
+        self.server.vad_detector = MagicMock(return_value=True)
+        self.server.process_audio_frames(ws)
+        np.testing.assert_array_equal(self.server.vad_detector.call_args[0][0], denoised)
+
+    @patch("whisper_live.server.serve")
+    def test_run_stores_preprocessor(self, mock_serve):
+        def preprocessor(frame, sample_rate):
+            return frame
+
+        server = TranscriptionServer()
+        server.run("0.0.0.0", backend="faster_whisper", audio_preprocessor=preprocessor)
+        self.assertIs(server.audio_preprocessor, preprocessor)
+
+    def test_initialize_client_attaches_preprocessor(self):
+        def preprocessor(frame, sample_rate):
+            return frame
+
+        server = TranscriptionServer()
+        server.backend = BackendType.FASTER_WHISPER
+        server.cache_path = "~/.cache/whisper-live/"
+        server.client_manager = ClientManager(max_clients=2, max_connection_time=60)
+        ws = MagicMock()
+        options = {"uid": "abc", "language": "en", "task": "transcribe", "model": "small"}
+        with patch("whisper_live.backend.faster_whisper_backend.ServeClientFasterWhisper") as mock_backend:
+            server.initialize_client(ws, options, None, None, False, audio_preprocessor=preprocessor)
+        client = server.client_manager.get_client(ws)
+        self.assertIs(client.audio_preprocessor, preprocessor)
+
+
+class TestKnownSpeakersOverWebSocket(unittest.TestCase):
+    """Tests for known_speakers enrollment sent in the WebSocket handshake."""
+
+    def setUp(self):
+        self.server = TranscriptionServer()
+        self.diarizer = MagicMock()
+        self.diarizer.enroll_speaker.return_value = True
+
+    def _options(self, **extra):
+        import base64
+
+        options = {
+            "uid": "abc",
+            "known_speakers": [
+                {"name": "alice", "audio_base64": base64.b64encode(b"RIFFfake").decode()},
+            ],
+        }
+        options.update(extra)
+        return options
+
+    def _create_diarizer(self, options):
+        import numpy as np
+
+        with patch("whisper_live.diarization.SpeakerDiarizer", return_value=self.diarizer), \
+                patch("whisper_live.diarization.load_audio", return_value=np.zeros(16000, dtype="float32")):
+            return self.server._create_diarizer(options)
+
+    def test_known_speakers_alone_create_a_diarizer(self):
+        diarizer = self._create_diarizer(self._options())
+        self.assertIs(diarizer, self.diarizer)
+
+    def test_known_speakers_are_enrolled(self):
+        self._create_diarizer(self._options())
+        self.diarizer.enroll_speaker.assert_called_once()
+        self.assertEqual(self.diarizer.enroll_speaker.call_args[0][0], "alice")
+
+    def test_multiple_known_speakers_enrolled(self):
+        import base64
+
+        speakers = [
+            {"name": "alice", "audio_base64": base64.b64encode(b"RIFFa").decode()},
+            {"name": "bob", "audio_base64": base64.b64encode(b"RIFFb").decode()},
+        ]
+        self._create_diarizer({"uid": "abc", "known_speakers": speakers})
+        enrolled = [call[0][0] for call in self.diarizer.enroll_speaker.call_args_list]
+        self.assertEqual(enrolled, ["alice", "bob"])
+
+    def test_no_known_speakers_and_no_diarization_returns_none(self):
+        self.assertIsNone(self.server._create_diarizer({"uid": "abc"}))
+
+    def test_diarization_without_known_speakers_enrolls_nothing(self):
+        diarizer = self._create_diarizer({"uid": "abc", "enable_diarization": True})
+        self.assertIs(diarizer, self.diarizer)
+        self.diarizer.enroll_speaker.assert_not_called()
+
+    def test_speaker_without_audio_is_skipped(self):
+        self._create_diarizer({"uid": "abc", "known_speakers": [{"name": "alice"}]})
+        self.diarizer.enroll_speaker.assert_not_called()
+
+    def test_invalid_base64_does_not_raise(self):
+        import numpy as np
+
+        with patch("whisper_live.diarization.load_audio", return_value=np.zeros(16000, dtype="float32")):
+            TranscriptionServer._enroll_known_speakers(
+                self.diarizer,
+                [{"name": "alice", "audio_base64": "not base64 @@@"}],
+            )
+        self.diarizer.enroll_speaker.assert_not_called()
+
+    def test_too_short_reference_is_reported_not_raised(self):
+        import base64
+        import numpy as np
+
+        self.diarizer.enroll_speaker.return_value = False
+        with patch("whisper_live.diarization.load_audio", return_value=np.zeros(10, dtype="float32")):
+            TranscriptionServer._enroll_known_speakers(
+                self.diarizer,
+                [{"name": "alice", "audio_base64": base64.b64encode(b"RIFFa").decode()}],
+            )
+        self.diarizer.enroll_speaker.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()
 

--- a/whisper_live/backend/base.py
+++ b/whisper_live/backend/base.py
@@ -92,6 +92,12 @@ class ServeClientBase(object):
         # projects emit cross-segment results (e.g. paragraph grouping).
         self.transcript_finalizer = None
 
+        # Optional pre-processing callable for incoming audio.
+        # If set, called with (frame_np, sample_rate) and must return a numpy
+        # array of samples. Applied by the server before VAD and add_frames,
+        # so external projects can run noise reduction on live audio.
+        self.audio_preprocessor = None
+
         # threading
         self.lock = threading.Lock()
         self.frames_ready = threading.Event()

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -1,3 +1,5 @@
+import base64
+import binascii
 import os
 import time
 import threading
@@ -29,6 +31,21 @@ from whisper_live.vad import VoiceActivityDetector
 from whisper_live.backend.base import ServeClientBase
 
 logging.basicConfig(level=logging.INFO)
+
+# Model name OpenAI clients send when they do not name a whisper size.
+OPENAI_MODEL_ALIAS = "whisper-1"
+
+# faster-whisper model sizes that can be passed straight to WhisperModel().
+STOCK_MODEL_SIZES = frozenset({
+    "tiny", "tiny.en",
+    "base", "base.en",
+    "small", "small.en",
+    "medium", "medium.en",
+    "large-v2", "large-v3", "large-v3-turbo",
+})
+
+# REST routes that stay reachable without an API key.
+API_KEY_EXEMPT_PATHS = frozenset({"/docs", "/redoc", "/openapi.json", "/health"})
 
 
 def _websocket_auth(api_key, connection, request):
@@ -216,10 +233,15 @@ class TranscriptionServer:
         self.audio_formats = {}
         self.segment_post_processor = None
         self.transcript_finalizer = None
+        self.audio_preprocessor = None
+        self.default_model = "small"
+        self.rest_models = {}
+        self.rest_models_lock = threading.Lock()
 
     def initialize_client(
         self, websocket, options, faster_whisper_custom_model_path,
         whisper_tensorrt_path, trt_multilingual, trt_py_session=False,
+        audio_preprocessor=None,
     ):
         client: Optional[ServeClientBase] = None
 
@@ -365,6 +387,8 @@ class TranscriptionServer:
         if self.transcript_finalizer is not None:
             client.transcript_finalizer = self.transcript_finalizer
 
+        client.audio_preprocessor = audio_preprocessor or self.audio_preprocessor
+
         if translation_client:
             client.translation_client = translation_client
             client.translation_thread = translation_thread
@@ -374,21 +398,59 @@ class TranscriptionServer:
     def _create_diarizer(self, options):
         """Create a SpeakerDiarizer if the client requested diarization.
 
+        Diarization is created when the handshake sets ``enable_diarization`` or
+        carries ``known_speakers``. Each known speaker is a dict with a ``name``
+        and base64-encoded reference audio under ``audio_base64``.
+
         Returns:
             SpeakerDiarizer or None
         """
-        if not options.get("enable_diarization", False):
+        known_speakers = options.get("known_speakers") or []
+        if not options.get("enable_diarization", False) and not known_speakers:
             return None
         try:
             from whisper_live.diarization import SpeakerDiarizer
-            return SpeakerDiarizer(
+            diarizer = SpeakerDiarizer(
                 similarity_threshold=options.get("diarization_threshold", 0.55),
-                max_speakers=options.get("max_speakers", 10),
+                max_speakers=max(options.get("max_speakers", 10), len(known_speakers)),
                 hf_token=options.get("hf_token"),
             )
         except ImportError:
             logging.warning("pyannote.audio not installed; diarization disabled")
             return None
+        self._enroll_known_speakers(diarizer, known_speakers)
+        return diarizer
+
+    @staticmethod
+    def _enroll_known_speakers(diarizer, known_speakers):
+        """Enroll base64-encoded reference clips from the handshake into a diarizer.
+
+        Args:
+            diarizer (SpeakerDiarizer): The diarizer to enroll into.
+            known_speakers (list): Dicts with ``name`` and ``audio_base64`` keys.
+        """
+        from whisper_live.diarization import load_audio
+
+        for speaker in known_speakers:
+            name = speaker.get("name")
+            audio_base64 = speaker.get("audio_base64")
+            if not name or not audio_base64:
+                logging.warning("Skipping known speaker without a name or audio_base64")
+                continue
+            reference_path = None
+            try:
+                with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as tmp:
+                    tmp.write(base64.b64decode(audio_base64))
+                    reference_path = tmp.name
+                if diarizer.enroll_speaker(name, load_audio(reference_path)):
+                    logging.info(f"Enrolled known speaker '{name}'")
+                else:
+                    logging.warning(f"Reference audio for known speaker '{name}' is too short")
+            except (binascii.Error, ValueError) as e:
+                logging.error(f"Failed to enroll known speaker '{name}': {e}")
+            finally:
+                if reference_path and os.path.exists(reference_path):
+                    os.unlink(reference_path)
 
     def get_audio_from_websocket(self, websocket):
         """
@@ -482,6 +544,13 @@ class TranscriptionServer:
                 client.set_eos(True)
             return False
 
+        preprocessor = getattr(client, "audio_preprocessor", None)
+        if preprocessor is not None:
+            try:
+                frame_np = preprocessor(frame_np, self.RATE)
+            except Exception as e:
+                logging.error(f"audio_preprocessor failed: {e}")
+
         if self.backend.is_tensorrt():
             voice_active = self.voice_activity(websocket, frame_np)
             if voice_active:
@@ -549,10 +618,55 @@ class TranscriptionServer:
             wl_metrics.track_connection_closed()
             del websocket
 
+    def _resolve_rest_model(self, requested_model):
+        """Map the REST ``model`` form field onto a faster-whisper model name.
+
+        Accepts a stock size name, a local path or a HuggingFace repo id. Anything
+        else, including the ``whisper-1`` alias and an absent field, falls back to
+        the server's default model.
+
+        Args:
+            requested_model (str or None): The ``model`` value sent by the client.
+
+        Returns:
+            str: The model name or path to load.
+        """
+        if not requested_model or requested_model == OPENAI_MODEL_ALIAS:
+            return self.default_model
+        if requested_model in STOCK_MODEL_SIZES:
+            return requested_model
+        if os.path.exists(requested_model) or "/" in requested_model:
+            return requested_model
+        logging.warning(f"Unknown model '{requested_model}'; using '{self.default_model}' instead.")
+        return self.default_model
+
+    def _get_rest_model(self, model_name):
+        """Return a cached ``WhisperModel`` for ``model_name``, loading it once.
+
+        Args:
+            model_name (str): Model name or path accepted by faster-whisper.
+
+        Returns:
+            WhisperModel: The shared model instance for that name.
+        """
+        with self.rest_models_lock:
+            transcriber = self.rest_models.get(model_name)
+            if transcriber is None:
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+                compute_type = "float16" if device == "cuda" else "int8"
+                logging.info(f"Loading REST model '{model_name}' on {device}")
+                transcriber = WhisperModel(model_name, device=device, compute_type=compute_type)
+                self.rest_models[model_name] = transcriber
+            return transcriber
+
     def _stream_transcription(self, file, language, prompt, temperature,
                               timestamp_granularities,
-                              faster_whisper_custom_model_path):
-        """Return a StreamingResponse that yields SSE events per segment."""
+                              requested_model=None):
+        """Return a StreamingResponse that yields SSE events per segment.
+
+        The first event carries the detected language and its probability, then
+        one event per segment, then ``[DONE]``.
+        """
 
         async def _sse_generator():
             tmp_path = None
@@ -562,10 +676,7 @@ class TranscriptionServer:
                     shutil.copyfileobj(file.file, tmp)
                     tmp_path = tmp.name
 
-                device = "cuda" if torch.cuda.is_available() else "cpu"
-                compute_type = "float16" if device == "cuda" else "int8"
-                model_name = faster_whisper_custom_model_path or "small"
-                transcriber = WhisperModel(model_name, device=device, compute_type=compute_type)
+                transcriber = self._get_rest_model(self._resolve_rest_model(requested_model))
                 segments, info = transcriber.transcribe(
                     tmp_path,
                     language=language,
@@ -574,6 +685,13 @@ class TranscriptionServer:
                     vad_filter=False,
                     word_timestamps=(timestamp_granularities and "word" in timestamp_granularities),
                 )
+
+                metadata = {
+                    "type": "metadata",
+                    "language": info.language,
+                    "language_probability": info.language_probability,
+                }
+                yield f"data: {json.dumps(metadata)}\n\n"
 
                 for seg in segments:
                     seg_dict = {
@@ -659,6 +777,205 @@ class TranscriptionServer:
                 labels[index] = speaker
         return labels
 
+    def build_rest_app(self, backend, faster_whisper_custom_model_path=None,
+                       whisper_tensorrt_path=None, cors_origins=None,
+                       api_key=None, rate_limit_rpm=0):
+        """Build the OpenAI-compatible REST app served alongside the WebSocket server.
+
+        Args:
+            backend (str): Backend name reported by ``/health``.
+            faster_whisper_custom_model_path (str, optional): Custom model reported by ``/health``.
+            whisper_tensorrt_path (str, optional): TensorRT model reported by ``/health``.
+            cors_origins (str, optional): Comma-separated list of allowed CORS origins.
+            api_key (str, optional): When set, every route except ``API_KEY_EXEMPT_PATHS``
+                requires an ``Authorization: Bearer`` header carrying this key.
+            rate_limit_rpm (int): Requests per minute per client IP. 0 disables the limit.
+
+        Returns:
+            FastAPI: The configured app.
+        """
+        app = FastAPI(title="WhisperLive OpenAI-Compatible API")
+        origins = [o.strip() for o in cors_origins.split(',')] if cors_origins else []
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=origins,
+            allow_credentials=True,
+            allow_methods=["*"],  # Allows all methods (GET, POST, etc.)
+            allow_headers=["*"],  # Allows all headers
+        )
+
+        # Optional API key authentication
+        if api_key:
+            @app.middleware("http")
+            async def _check_api_key(request: Request, call_next):
+                if request.url.path not in API_KEY_EXEMPT_PATHS:
+                    auth = request.headers.get("Authorization", "")
+                    if auth != f"Bearer {api_key}":
+                        return JSONResponse({"error": "Invalid or missing API key"}, status_code=401)
+                return await call_next(request)
+
+        # Optional rate limiting (requests per minute per client IP)
+        if rate_limit_rpm > 0:
+            _rate_lock = threading.Lock()
+            _rate_buckets: dict = {}  # ip -> deque of timestamps
+
+            @app.middleware("http")
+            async def _rate_limit(request: Request, call_next):
+                client_ip = request.client.host if request.client else "unknown"
+                now = time.time()
+                with _rate_lock:
+                    bucket = _rate_buckets.setdefault(client_ip, collections.deque())
+                    # Discard entries older than 60s
+                    while bucket and bucket[0] < now - 60:
+                        bucket.popleft()
+                    if len(bucket) >= rate_limit_rpm:
+                        return JSONResponse({"error": "Rate limit exceeded"}, status_code=429)
+                    bucket.append(now)
+                return await call_next(request)
+
+        health_model = faster_whisper_custom_model_path or whisper_tensorrt_path or self.default_model
+
+        @app.get("/health")
+        async def health():
+            """Report backend, model and client occupancy without requiring an API key."""
+            return {
+                "status": "ok",
+                "backend": backend,
+                "model": health_model,
+                "clients": len(self.client_manager.clients),
+                "max_clients": self.client_manager.max_clients,
+            }
+
+        @app.post("/v1/audio/transcriptions")
+        async def transcribe(
+            file: UploadFile,
+            model: str = Form(default="whisper-1"),
+            language: Optional[str] = Form(default=None),
+            prompt: Optional[str] = Form(default=None),
+            response_format: str = Form(default="json"),
+            temperature: float = Form(default=0.0),
+            timestamp_granularities: Optional[List[str]] = Form(default=None),
+            # Stubs for unsupported OpenAI params
+            chunking_strategy: Optional[str] = Form(default=None),
+            include: Optional[List[str]] = Form(default=None),
+            known_speaker_names: Optional[List[str]] = Form(default=None),
+            known_speaker_references: Optional[List[UploadFile]] = File(default=None),
+            stream: bool = Form(default=False),
+            hotwords: Optional[str] = Form(default=None),
+        ):
+            if stream:
+                return self._stream_transcription(
+                    file, language, prompt, temperature,
+                    timestamp_granularities,
+                    model,
+                )
+
+            ignored_params = []
+            if chunking_strategy:
+                ignored_params.append(f"chunking_strategy='{chunking_strategy}'")
+            if include:
+                ignored_params.append(f"include={include}")
+            if ignored_params:
+                logging.warning(f"Unsupported OpenAI params ignored: {', '.join(ignored_params)}")
+
+            supported_formats = ["json", "text", "srt", "verbose_json", "vtt"]
+            if response_format not in supported_formats:
+                wl_metrics.track_rest_request(endpoint="transcriptions", status=400)
+                return JSONResponse({"error": f"Unsupported response_format. Supported: {supported_formats}"}, status_code=400)
+
+            model_name = self._resolve_rest_model(model)
+
+            tmp_path = None
+            try:
+                suffix = os.path.splitext(file.filename)[1] or ".wav"
+                with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+                    shutil.copyfileobj(file.file, tmp)
+                    tmp_path = tmp.name
+
+                transcriber = self._get_rest_model(model_name)
+                segments, info = transcriber.transcribe(
+                    tmp_path,
+                    language=language,
+                    initial_prompt=prompt,
+                    temperature=temperature,
+                    vad_filter=False,
+                    word_timestamps=(timestamp_granularities and "word" in timestamp_granularities),
+                    hotwords=hotwords,
+                )
+                segments = list(segments)
+
+                text = " ".join([s.text.strip() for s in segments])
+
+                if response_format == "text":
+                    wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
+                    return PlainTextResponse(text)
+                elif response_format == "json":
+                    wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
+                    return {
+                        "text": text,
+                        "language": info.language,
+                        "language_probability": info.language_probability,
+                    }
+                elif response_format == "verbose_json":
+                    verbose = {
+                        "task": "transcribe",
+                        "language": info.language,
+                        "language_probability": info.language_probability,
+                        "duration": info.duration,
+                        "text": text,
+                        "segments": []
+                    }
+                    speaker_labels = {}
+                    try:
+                        rest_diarizer = await self._create_rest_diarizer(known_speaker_names, known_speaker_references)
+                    except ValueError as e:
+                        wl_metrics.track_rest_request(endpoint="transcriptions", status=400)
+                        return JSONResponse({"error": str(e)}, status_code=400)
+                    if rest_diarizer is not None:
+                        from whisper_live.diarization import load_audio
+                        audio_np = load_audio(tmp_path)
+                        speaker_labels = self._speaker_labels_for_segments(segments, audio_np, rest_diarizer)
+                    for index, seg in enumerate(segments):
+                        seg_dict = {
+                            "id": seg.id,
+                            "seek": seg.seek,
+                            "start": seg.start,
+                            "end": seg.end,
+                            "text": seg.text.strip(),
+                            "tokens": seg.tokens,
+                            "temperature": seg.temperature,
+                            "avg_logprob": seg.avg_logprob,
+                            "compression_ratio": seg.compression_ratio,
+                            "no_speech_prob": seg.no_speech_prob
+                        }
+                        if index in speaker_labels:
+                            seg_dict["speaker"] = speaker_labels[index]
+                        if timestamp_granularities and "word" in timestamp_granularities:
+                            seg_dict["words"] = [{"word": w.word, "start": w.start, "end": w.end, "probability": w.probability} for w in seg.words]
+                        verbose["segments"].append(seg_dict)
+                    wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
+                    return verbose
+                elif response_format in ["srt", "vtt"]:
+                    output = []
+                    for i, seg in enumerate(segments, 1):
+                        start = f"{int(seg.start // 3600):02}:{int((seg.start % 3600) // 60):02}:{seg.start % 60:06.3f}"
+                        end = f"{int(seg.end // 3600):02}:{int((seg.end % 3600) // 60):02}:{seg.end % 60:06.3f}"
+                        if response_format == "srt":
+                            output.append(f"{i}\n{start.replace('.', ',')} --> {end.replace('.', ',')}\n{seg.text.strip()}\n")
+                        else:  # vtt
+                            output.append(f"{start} --> {end}\n{seg.text.strip()}\n")
+                    wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
+                    return PlainTextResponse("\n".join(output))
+            except Exception as e:
+                wl_metrics.track_rest_request(endpoint="transcriptions", status=500)
+                wl_metrics.track_error("rest_transcription")
+                return JSONResponse({"error": str(e)}, status_code=500)
+            finally:
+                if tmp_path and os.path.exists(tmp_path):
+                    os.unlink(tmp_path)
+
+        return app
+
     def run(self,
             host,
             port=9090,
@@ -686,7 +1003,9 @@ class TranscriptionServer:
             api_key: Optional[str] = None,
             rate_limit_rpm: int = 0,
             segment_post_processor=None,
-            transcript_finalizer=None):
+            transcript_finalizer=None,
+            audio_preprocessor=None,
+            default_model: str = "small"):
         """
         Run the transcription server.
 
@@ -724,9 +1043,19 @@ class TranscriptionServer:
                 while the socket is still open, and may return a dict sent to the
                 client as a final message. Useful for cross-segment results (e.g.
                 paragraph grouping). Defaults to None.
+            audio_preprocessor (callable, optional): A callable
+                ``(frame_np, sample_rate) -> np.ndarray`` applied to every audio
+                frame before VAD and before it reaches the backend. Useful for
+                plugging in noise reduction on live audio. Defaults to None.
+            default_model (str): The faster-whisper model the REST endpoint loads
+                when the request's ``model`` field is ``whisper-1`` or absent.
+                Defaults to "small". A custom model passed with
+                ``faster_whisper_custom_model_path`` takes precedence.
         """
         self.cache_path = cache_path
         self.raw_pcm_input = raw_pcm_input
+        self.audio_preprocessor = audio_preprocessor
+        self.default_model = faster_whisper_custom_model_path or default_model
 
         if max_clients < 1:
             raise ValueError(f"max_clients must be >= 1, got {max_clients}")
@@ -786,172 +1115,14 @@ class TranscriptionServer:
 
         # New OpenAI-compatible REST API (toggleable via enable_rest boolean)
         if enable_rest:
-            app = FastAPI(title="WhisperLive OpenAI-Compatible API")
-            origins = [o.strip() for o in cors_origins.split(',')] if cors_origins else []
-            app.add_middleware(
-                CORSMiddleware,
-                allow_origins=origins,
-                allow_credentials=True,
-                allow_methods=["*"],  # Allows all methods (GET, POST, etc.)
-                allow_headers=["*"],  # Allows all headers
+            app = self.build_rest_app(
+                backend,
+                faster_whisper_custom_model_path=faster_whisper_custom_model_path,
+                whisper_tensorrt_path=whisper_tensorrt_path,
+                cors_origins=cors_origins,
+                api_key=api_key,
+                rate_limit_rpm=rate_limit_rpm,
             )
-
-            # Optional API key authentication
-            if api_key:
-                @app.middleware("http")
-                async def _check_api_key(request: Request, call_next):
-                    auth = request.headers.get("Authorization", "")
-                    if auth != f"Bearer {api_key}":
-                        return JSONResponse({"error": "Invalid or missing API key"}, status_code=401)
-                    return await call_next(request)
-
-            # Optional rate limiting (requests per minute per client IP)
-            if rate_limit_rpm > 0:
-                _rate_lock = threading.Lock()
-                _rate_buckets: dict = {}  # ip -> deque of timestamps
-
-                @app.middleware("http")
-                async def _rate_limit(request: Request, call_next):
-                    client_ip = request.client.host if request.client else "unknown"
-                    now = time.time()
-                    with _rate_lock:
-                        bucket = _rate_buckets.setdefault(client_ip, collections.deque())
-                        # Discard entries older than 60s
-                        while bucket and bucket[0] < now - 60:
-                            bucket.popleft()
-                        if len(bucket) >= rate_limit_rpm:
-                            return JSONResponse({"error": "Rate limit exceeded"}, status_code=429)
-                        bucket.append(now)
-                    return await call_next(request)
-
-
-            @app.post("/v1/audio/transcriptions")
-            async def transcribe(
-                file: UploadFile,
-                model: str = Form(default="whisper-1"),
-                language: Optional[str] = Form(default=None),
-                prompt: Optional[str] = Form(default=None),
-                response_format: str = Form(default="json"),
-                temperature: float = Form(default=0.0),
-                timestamp_granularities: Optional[List[str]] = Form(default=None),
-                # Stubs for unsupported OpenAI params
-                chunking_strategy: Optional[str] = Form(default=None),
-                include: Optional[List[str]] = Form(default=None),
-                known_speaker_names: Optional[List[str]] = Form(default=None),
-                known_speaker_references: Optional[List[UploadFile]] = File(default=None),
-                stream: bool = Form(default=False),
-                hotwords: Optional[str] = Form(default=None),
-            ):
-                if stream:
-                    return self._stream_transcription(
-                        file, language, prompt, temperature,
-                        timestamp_granularities,
-                        faster_whisper_custom_model_path,
-                    )
-
-                ignored_params = []
-                if chunking_strategy:
-                    ignored_params.append(f"chunking_strategy='{chunking_strategy}'")
-                if include:
-                    ignored_params.append(f"include={include}")
-                if ignored_params:
-                    logging.warning(f"Unsupported OpenAI params ignored: {', '.join(ignored_params)}")
-
-                supported_formats = ["json", "text", "srt", "verbose_json", "vtt"]
-                if response_format not in supported_formats:
-                    wl_metrics.track_rest_request(endpoint="transcriptions", status=400)
-                    return JSONResponse({"error": f"Unsupported response_format. Supported: {supported_formats}"}, status_code=400)
-
-                if model != "whisper-1":
-                    logging.warning(f"Model '{model}' requested; using 'small' as fallback.")
-                model_name = faster_whisper_custom_model_path or "small"
-
-                tmp_path = None
-                try:
-                    suffix = os.path.splitext(file.filename)[1] or ".wav"
-                    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
-                        shutil.copyfileobj(file.file, tmp)
-                        tmp_path = tmp.name
-
-                    device = "cuda" if torch.cuda.is_available() else "cpu"
-                    compute_type = "float16" if device == "cuda" else "int8"
-
-                    transcriber = WhisperModel(model_name, device=device, compute_type=compute_type)
-                    segments, info = transcriber.transcribe(
-                        tmp_path,
-                        language=language,
-                        initial_prompt=prompt,
-                        temperature=temperature,
-                        vad_filter=False,
-                        word_timestamps=(timestamp_granularities and "word" in timestamp_granularities),
-                        hotwords=hotwords,
-                    )
-                    segments = list(segments)
-
-                    text = " ".join([s.text.strip() for s in segments])
-
-                    if response_format == "text":
-                        wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
-                        return PlainTextResponse(text)
-                    elif response_format == "json":
-                        wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
-                        return {"text": text}
-                    elif response_format == "verbose_json":
-                        verbose = {
-                            "task": "transcribe",
-                            "language": info.language,
-                            "duration": info.duration,
-                            "text": text,
-                            "segments": []
-                        }
-                        speaker_labels = {}
-                        try:
-                            rest_diarizer = await self._create_rest_diarizer(known_speaker_names, known_speaker_references)
-                        except ValueError as e:
-                            wl_metrics.track_rest_request(endpoint="transcriptions", status=400)
-                            return JSONResponse({"error": str(e)}, status_code=400)
-                        if rest_diarizer is not None:
-                            from whisper_live.diarization import load_audio
-                            audio_np = load_audio(tmp_path)
-                            speaker_labels = self._speaker_labels_for_segments(segments, audio_np, rest_diarizer)
-                        for index, seg in enumerate(segments):
-                            seg_dict = {
-                                "id": seg.id,
-                                "seek": seg.seek,
-                                "start": seg.start,
-                                "end": seg.end,
-                                "text": seg.text.strip(),
-                                "tokens": seg.tokens,
-                                "temperature": seg.temperature,
-                                "avg_logprob": seg.avg_logprob,
-                                "compression_ratio": seg.compression_ratio,
-                                "no_speech_prob": seg.no_speech_prob
-                            }
-                            if index in speaker_labels:
-                                seg_dict["speaker"] = speaker_labels[index]
-                            if timestamp_granularities and "word" in timestamp_granularities:
-                                seg_dict["words"] = [{"word": w.word, "start": w.start, "end": w.end, "probability": w.probability} for w in seg.words]
-                            verbose["segments"].append(seg_dict)
-                        wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
-                        return verbose
-                    elif response_format in ["srt", "vtt"]:
-                        output = []
-                        for i, seg in enumerate(segments, 1):
-                            start = f"{int(seg.start // 3600):02}:{int((seg.start % 3600) // 60):02}:{seg.start % 60:06.3f}"
-                            end = f"{int(seg.end // 3600):02}:{int((seg.end % 3600) // 60):02}:{seg.end % 60:06.3f}"
-                            if response_format == "srt":
-                                output.append(f"{i}\n{start.replace('.', ',')} --> {end.replace('.', ',')}\n{seg.text.strip()}\n")
-                            else:  # vtt
-                                output.append(f"{start} --> {end}\n{seg.text.strip()}\n")
-                        wl_metrics.track_rest_request(endpoint="transcriptions", status=200)
-                        return PlainTextResponse("\n".join(output))
-                except Exception as e:
-                    wl_metrics.track_rest_request(endpoint="transcriptions", status=500)
-                    wl_metrics.track_error("rest_transcription")
-                    return JSONResponse({"error": str(e)}, status_code=500)
-                finally:
-                    if tmp_path and os.path.exists(tmp_path):
-                        os.unlink(tmp_path)
 
             threading.Thread(
                 target=uvicorn.run,


### PR DESCRIPTION
re-applies #536 (reverted in #539), rebased on main with #535 merged. tests in `tests/test_server_extended.py`.

- `GET /health` on the rest app
- `--default_model` and per-request `model` field, loaded models cached per name
- docs and health paths exempt from the api key middleware
- `language` and `language_probability` in json responses and as an sse metadata event
- `audio_preprocessor` hook, applied before VAD
- `build_rest_app()` split out of `run()` for tests