### PR TITLE
client reconnect, known_speakers, websocket auth

### DIFF
--- a/tests/test_client_extended.py
+++ b/tests/test_client_extended.py
@@ -323,9 +323,10 @@ class TestClientReconnect(unittest.TestCase):
 class TestClientReconnectOnlyOnUnexpectedClose(unittest.TestCase):
     """Only closes the client did not ask for should trigger a reconnect."""
 
-    @patch("whisper_live.client.websocket.WebSocketApp")
-    @patch("whisper_live.client.pyaudio.PyAudio")
-    def setUp(self, mock_pyaudio, mock_websocket):
+    def setUp(self):
+        patch("whisper_live.client.websocket.WebSocketApp").start()
+        mock_pyaudio = patch("whisper_live.client.pyaudio.PyAudio").start()
+        self.addCleanup(patch.stopall)
         mock_pyaudio.return_value.open.return_value = MagicMock()
         self.client = Client(host="localhost", port=9090, lang="en", max_retries=2, retry_delay=0)
 

--- a/tests/test_client_extended.py
+++ b/tests/test_client_extended.py
@@ -320,5 +320,78 @@ class TestClientReconnect(unittest.TestCase):
         client.close_websocket()
 
 
+class TestClientReconnectOnlyOnUnexpectedClose(unittest.TestCase):
+    """Only closes the client did not ask for should trigger a reconnect."""
+
+    @patch("whisper_live.client.websocket.WebSocketApp")
+    @patch("whisper_live.client.pyaudio.PyAudio")
+    def setUp(self, mock_pyaudio, mock_websocket):
+        mock_pyaudio.return_value.open.return_value = MagicMock()
+        self.client = Client(host="localhost", port=9090, lang="en", max_retries=2, retry_delay=0)
+
+    def tearDown(self):
+        self.client.close_websocket()
+
+    def _disconnect_message(self):
+        return json.dumps({"uid": self.client.uid, "message": "DISCONNECT"})
+
+    def test_no_reconnect_after_close_websocket(self):
+        self.client.close_websocket()
+        self.client.on_close(MagicMock(), 1006, "abnormal closure")
+        self.assertEqual(self.client._retry_count, 0)
+
+    def test_no_reconnect_after_end_of_audio(self):
+        self.client.send_packet_to_server(Client.END_OF_AUDIO.encode("utf-8"))
+        self.client.on_close(MagicMock(), 1006, "server closed after final segment")
+        self.assertEqual(self.client._retry_count, 0)
+
+    def test_no_reconnect_on_normal_close_after_disconnect(self):
+        self.client.on_message(MagicMock(), self._disconnect_message())
+        self.client.on_close(MagicMock(), Client.NORMAL_CLOSURE, "normal")
+        self.assertEqual(self.client._retry_count, 0)
+
+    def test_reconnect_on_abnormal_close_after_disconnect(self):
+        self.client.on_message(MagicMock(), self._disconnect_message())
+        self.client.on_close(MagicMock(), 1006, "abnormal closure")
+        self.assertEqual(self.client._retry_count, 1)
+
+    def test_reconnect_on_normal_close_without_disconnect(self):
+        self.client.on_close(MagicMock(), Client.NORMAL_CLOSURE, "normal")
+        self.assertEqual(self.client._retry_count, 1)
+
+    def test_audio_packets_do_not_mark_a_client_close(self):
+        self.client.send_packet_to_server(b"\x00\x01\x02\x03")
+        self.assertFalse(self.client._client_initiated_close)
+        self.client.on_close(MagicMock(), 1006, "abnormal closure")
+        self.assertEqual(self.client._retry_count, 1)
+
+
+class TestClientKnownSpeakers(unittest.TestCase):
+    """Known speaker references are sent in the handshake."""
+
+    @patch("whisper_live.client.websocket.WebSocketApp")
+    @patch("whisper_live.client.pyaudio.PyAudio")
+    def _make_client(self, mock_pyaudio, mock_websocket, **kwargs):
+        mock_pyaudio.return_value.open.return_value = MagicMock()
+        return Client(host="localhost", port=9090, lang="en", **kwargs)
+
+    def test_known_speakers_included_in_handshake(self):
+        speakers = [{"name": "alice", "audio_base64": "UklGRmZha2U="}]
+        client = self._make_client(known_speakers=speakers)
+        ws = MagicMock()
+        client.on_open(ws)
+        sent = json.loads(ws.send.call_args[0][0])
+        self.assertEqual(sent["known_speakers"], speakers)
+        client.close_websocket()
+
+    def test_handshake_defaults_to_no_known_speakers(self):
+        client = self._make_client()
+        ws = MagicMock()
+        client.on_open(ws)
+        sent = json.loads(ws.send.call_args[0][0])
+        self.assertEqual(sent["known_speakers"], [])
+        client.close_websocket()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -8,7 +8,14 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 from websockets.http11 import Request
 
-from whisper_live.server import TranscriptionServer, BackendType, ClientManager, _websocket_auth
+from whisper_live.server import (
+    BEARER_SUBPROTOCOL,
+    TranscriptionServer,
+    BackendType,
+    ClientManager,
+    _select_bearer_subprotocol,
+    _websocket_auth,
+)
 
 
 class TestClientManagerAddRemove(unittest.TestCase):
@@ -750,6 +757,74 @@ class TestWebSocketAuth(unittest.TestCase):
         handler = self._make_auth_handler("my-secret")
         result = handler("/?token=wrong", {})
         self.assertEqual(result[0], 401)
+
+
+class TestBearerSubprotocolSelection(unittest.TestCase):
+    """Tests for the select_subprotocol callback passed to serve()."""
+
+    def test_bearer_offer_is_echoed(self):
+        selected = _select_bearer_subprotocol(MagicMock(), [BEARER_SUBPROTOCOL, "a.jwt.token"])
+        self.assertEqual(selected, BEARER_SUBPROTOCOL)
+
+    def test_the_token_is_never_selected(self):
+        selected = _select_bearer_subprotocol(MagicMock(), ["a.jwt.token"])
+        self.assertIsNone(selected)
+
+    def test_no_offer_selects_nothing(self):
+        self.assertIsNone(_select_bearer_subprotocol(MagicMock(), []))
+
+
+class TestRunWebsocketAuthWiring(unittest.TestCase):
+    """Tests that run() wires websocket_auth and the subprotocol into serve()."""
+
+    def _serve_kwargs(self, mock_serve, **run_kwargs):
+        TranscriptionServer().run("0.0.0.0", backend="faster_whisper", **run_kwargs)
+        return mock_serve.call_args.kwargs
+
+    def _refuse(self, connection, request):
+        return connection.respond(HTTPStatus.UNAUTHORIZED, "Unauthorized\n")
+
+    @patch("whisper_live.server.serve")
+    def test_subprotocol_is_always_selected(self, mock_serve):
+        kwargs = self._serve_kwargs(mock_serve)
+        self.assertIs(kwargs["select_subprotocol"], _select_bearer_subprotocol)
+        self.assertNotIn("process_request", kwargs)
+
+    @patch("whisper_live.server.serve")
+    def test_websocket_auth_becomes_process_request(self, mock_serve):
+        kwargs = self._serve_kwargs(mock_serve, websocket_auth=self._refuse)
+        connection = MagicMock()
+        connection.respond.return_value = (401, [], b"Unauthorized\n")
+        result = kwargs["process_request"](connection, Request("/", {}))
+        self.assertEqual(result[0], 401)
+
+    @patch("whisper_live.server.serve")
+    def test_the_api_key_alone_does_not_admit_a_connection(self, mock_serve):
+        kwargs = self._serve_kwargs(mock_serve, api_key="my-secret", websocket_auth=self._refuse)
+        connection = MagicMock()
+        connection.respond.return_value = (401, [], b"Unauthorized\n")
+        request = Request("/", {"Authorization": "Bearer my-secret"})
+        self.assertEqual(kwargs["process_request"](connection, request)[0], 401)
+
+    @patch("whisper_live.server.serve")
+    def test_websocket_auth_alone_does_not_admit_a_connection(self, mock_serve):
+        def admit(connection, request):
+            return None
+
+        kwargs = self._serve_kwargs(mock_serve, api_key="my-secret", websocket_auth=admit)
+        connection = MagicMock()
+        connection.respond.return_value = (401, [], b"Unauthorized\n")
+        request = Request("/", {"Authorization": "Bearer wrong"})
+        self.assertEqual(kwargs["process_request"](connection, request)[0], 401)
+
+    @patch("whisper_live.server.serve")
+    def test_both_checks_passing_admits_the_connection(self, mock_serve):
+        def admit(connection, request):
+            return None
+
+        kwargs = self._serve_kwargs(mock_serve, api_key="my-secret", websocket_auth=admit)
+        request = Request("/", {"Authorization": "Bearer my-secret"})
+        self.assertIsNone(kwargs["process_request"](MagicMock(), request))
 
 
 def _make_transcription_info(language="en", language_probability=0.97, duration=1.0):

--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -758,6 +758,21 @@ class TestWebSocketAuth(unittest.TestCase):
         result = handler("/?token=wrong", {})
         self.assertEqual(result[0], 401)
 
+    def test_valid_bearer_subprotocol_token(self):
+        handler = self._make_auth_handler("my-secret")
+        result = handler("/", {"Sec-WebSocket-Protocol": "bearer, my-secret"})
+        self.assertIsNone(result)
+
+    def test_invalid_bearer_subprotocol_token(self):
+        handler = self._make_auth_handler("my-secret")
+        result = handler("/", {"Sec-WebSocket-Protocol": "bearer, wrong"})
+        self.assertEqual(result[0], 401)
+
+    def test_subprotocol_token_without_bearer_marker(self):
+        handler = self._make_auth_handler("my-secret")
+        result = handler("/", {"Sec-WebSocket-Protocol": "my-secret"})
+        self.assertEqual(result[0], 401)
+
 
 class TestBearerSubprotocolSelection(unittest.TestCase):
     """Tests for the select_subprotocol callback passed to serve()."""

--- a/whisper_live/client.py
+++ b/whisper_live/client.py
@@ -21,6 +21,7 @@ class Client:
     """
     INSTANCES = {}
     END_OF_AUDIO = "END_OF_AUDIO"
+    NORMAL_CLOSURE = 1000
 
     def __init__(
         self,
@@ -47,6 +48,7 @@ class Client:
         hotwords=None,
         enable_diarization=False,
         max_speakers=10,
+        known_speakers=None,
         word_timestamps=False,
         max_retries=0,
         retry_delay=5,
@@ -81,6 +83,13 @@ class Client:
             display_segments (int, optional): Number of recent transcript segments to display, and the maximum lines printed. Defaults to 4.
             initial_prompt (str, optional): Optional text to provide context to the model (e.g. domain vocabulary or names). Default is None.
             vad_parameters (dict, optional): Optional voice-activity-detection parameters passed to the server backend. Default is None.
+            known_speakers (list, optional): Reference clips to enroll in the server's diarizer at connection
+                time, as dicts of ``{"name": str, "audio_base64": str}`` where the audio is base64-encoded WAV
+                bytes. Default is None.
+            max_retries (int, optional): Number of reconnect attempts after an unexpected close. A close this
+                client asked for, a normal close after the server sent DISCONNECT, and a server error are not
+                retried. Default is 0.
+            retry_delay (int, optional): Seconds to wait before each reconnect attempt. Default is 5.
         """
         self.recording = False
         self.task = "transcribe"
@@ -120,10 +129,13 @@ class Client:
         self.hotwords = hotwords
         self.enable_diarization = enable_diarization
         self.max_speakers = max_speakers
+        self.known_speakers = known_speakers or []
         self.word_timestamps = word_timestamps
         self.max_retries = max_retries
         self.retry_delay = retry_delay
         self._retry_count = 0
+        self._client_initiated_close = False
+        self._server_disconnect = False
         self.audio_bytes = None
 
         if host is not None and port is not None:
@@ -149,6 +161,7 @@ class Client:
 
     def _create_websocket(self):
         """Creates a new WebSocketApp instance."""
+        self._server_disconnect = False
         self.client_socket = websocket.WebSocketApp(
             self.socket_url,
             on_open=lambda ws: self.on_open(ws),
@@ -271,6 +284,7 @@ class Client:
         if "message" in message.keys() and message["message"] == "DISCONNECT":
             print("[INFO]: Server disconnected due to overtime.")
             self.recording = False
+            self._server_disconnect = True
 
         if "message" in message.keys() and message["message"] == "SERVER_READY":
             self.last_response_received = time.time()
@@ -298,12 +312,33 @@ class Client:
         self.server_error = True
         self.error_message = error
 
+    def _should_reconnect(self, close_status_code):
+        """Decide whether an ``on_close`` should be followed by a reconnect.
+
+        Only unexpected closes are retried. A close this client asked for, a
+        normal close after the server said ``DISCONNECT``, and a close following
+        a server error are all treated as final.
+
+        Args:
+            close_status_code (int or None): The websocket close code.
+
+        Returns:
+            bool: True if a reconnect attempt should be made.
+        """
+        if self.max_retries <= 0 or self._retry_count >= self.max_retries:
+            return False
+        if self.server_error or self._client_initiated_close:
+            return False
+        if self._server_disconnect and close_status_code == self.NORMAL_CLOSURE:
+            return False
+        return True
+
     def on_close(self, ws, close_status_code, close_msg):
         print(f"[INFO]: Websocket connection closed: {close_status_code}: {close_msg}")
         self.recording = False
         self.waiting = False
 
-        if self.max_retries > 0 and self._retry_count < self.max_retries and not self.server_error:
+        if self._should_reconnect(close_status_code):
             self._retry_count += 1
             print(f"[INFO]: Reconnecting ({self._retry_count}/{self.max_retries}) in {self.retry_delay}s...")
             time.sleep(self.retry_delay)
@@ -341,6 +376,7 @@ class Client:
                     "hotwords": self.hotwords,
                     "enable_diarization": self.enable_diarization,
                     "max_speakers": self.max_speakers,
+                    "known_speakers": self.known_speakers,
                     "word_timestamps": self.word_timestamps,
                     "initial_prompt": self.initial_prompt,
                     "vad_parameters": self.vad_parameters,
@@ -359,6 +395,8 @@ class Client:
             Exception: If the WebSocket fails to send the packet.
 
         """
+        if message == Client.END_OF_AUDIO.encode("utf-8"):
+            self._client_initiated_close = True
         self.client_socket.send(message, websocket.ABNF.OPCODE_BINARY)
 
     def close_websocket(self):
@@ -369,6 +407,7 @@ class Client:
         closing the connection, it joins the WebSocket thread to ensure proper termination.
 
         """
+        self._client_initiated_close = True
         try:
             self.client_socket.close()
         except Exception as e:

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -70,13 +70,20 @@ def _all_websocket_checks(checks, connection, request):
     return None
 
 
+def _offered_subprotocols(request):
+    header = request.headers.get("Sec-WebSocket-Protocol", "")
+    return [name.strip() for name in header.split(",") if name.strip()]
+
+
 def _websocket_auth(api_key, connection, request):
     auth = request.headers.get("Authorization", "")
     token_param = None
     if "?" in request.path:
         parsed = urlparse(request.path)
         token_param = parse_qs(parsed.query).get("token", [None])[0]
-    if auth == f"Bearer {api_key}" or token_param == api_key:
+    offered = _offered_subprotocols(request)
+    bearer_subprotocol_token = BEARER_SUBPROTOCOL in offered and api_key in offered
+    if auth == f"Bearer {api_key}" or token_param == api_key or bearer_subprotocol_token:
         return None
     return connection.respond(HTTPStatus.UNAUTHORIZED, "Unauthorized\n")
 

--- a/whisper_live/server.py
+++ b/whisper_live/server.py
@@ -47,6 +47,28 @@ STOCK_MODEL_SIZES = frozenset({
 # REST routes that stay reachable without an API key.
 API_KEY_EXEMPT_PATHS = frozenset({"/docs", "/redoc", "/openapi.json", "/health"})
 
+# Subprotocol a browser offers as `new WebSocket(url, ["bearer", token])`.
+BEARER_SUBPROTOCOL = "bearer"
+
+
+def _select_bearer_subprotocol(connection, subprotocols):
+    """Echo the bearer marker, never the token beside it.
+
+    Chrome closes the socket when the 101 omits a subprotocol it offered.
+    """
+    if BEARER_SUBPROTOCOL in subprotocols:
+        return BEARER_SUBPROTOCOL
+    return None
+
+
+def _all_websocket_checks(checks, connection, request):
+    """Run every handshake check and return the first refusal."""
+    for check in checks:
+        response = check(connection, request)
+        if response is not None:
+            return response
+    return None
+
 
 def _websocket_auth(api_key, connection, request):
     auth = request.headers.get("Authorization", "")
@@ -1001,6 +1023,7 @@ class TranscriptionServer:
             raw_pcm_input=False,
             metrics_port: int = 0,
             api_key: Optional[str] = None,
+            websocket_auth=None,
             rate_limit_rpm: int = 0,
             segment_post_processor=None,
             transcript_finalizer=None,
@@ -1047,6 +1070,11 @@ class TranscriptionServer:
                 ``(frame_np, sample_rate) -> np.ndarray`` applied to every audio
                 frame before VAD and before it reaches the backend. Useful for
                 plugging in noise reduction on live audio. Defaults to None.
+            websocket_auth (callable, optional): A callable
+                ``(connection, request) -> Response | None`` passed to the
+                websocket server as ``process_request``. Returning a response
+                refuses the handshake. When ``api_key`` is also set both checks
+                must pass. Defaults to None.
             default_model (str): The faster-whisper model the REST endpoint loads
                 when the request's ``model`` field is ``whisper-1`` or absent.
                 Defaults to "small". A custom model passed with
@@ -1133,9 +1161,16 @@ class TranscriptionServer:
             logging.info(f"✅ OpenAI-Compatible API started on http://0.0.0.0:{rest_port}")
 
         # Original WebSocket server (always supported)
-        extra_ws_kwargs = {}
+        extra_ws_kwargs = {"select_subprotocol": _select_bearer_subprotocol}
+        handshake_checks = []
         if api_key:
-            extra_ws_kwargs["process_request"] = functools.partial(_websocket_auth, api_key)
+            handshake_checks.append(functools.partial(_websocket_auth, api_key))
+        if websocket_auth is not None:
+            handshake_checks.append(websocket_auth)
+        if handshake_checks:
+            extra_ws_kwargs["process_request"] = functools.partial(
+                _all_websocket_checks, handshake_checks
+            )
 
         with serve(
             functools.partial(


### PR DESCRIPTION
restores the client and websocket auth pieces that landed in #536 and were dropped by the #539 revert. tests in `tests/test_client_extended.py` and `tests/test_server_extended.py`.

- client reconnects only on unexpected closes
- `known_speakers` handshake option
- `websocket_auth` hook for the websocket handshake
- bearer token accepted as a subprotocol