### PR TITLE
raise pip timeout in install smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           python -m venv smoke-test-venv
           source smoke-test-venv/bin/activate
-          pip install dist/*.whl
+          pip install --timeout 120 dist/*.whl
           python -c "import whisper_live.client; import whisper_live.server"
 
   build-and-push-docker-cpu:


### PR DESCRIPTION
the venv install smoke test downloads the 581 MB cublas wheel from pypi. pip's default 15 second read timeout is easy to hit on that download and killed the main run after #541 merged, see https://github.com/collabora/WhisperLive/actions/runs/33728404780. a longer timeout is the only change that helps here, retries do not cover a stall in the middle of a download.